### PR TITLE
Make all operations `O(|key|+lgN)`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+Cargo.lock
+tst.dot

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,34 @@ fn get_r<'a, T>(link: &'a Link<T>, label: char, key_tail: &mut Chars) -> Option<
     }
 }
 
+fn get_nth_r<'a, T>(link: &'a Link<T>, mut n: usize, mut path: String) -> Option<(String, &'a T)> {
+    match *link {
+        None => None,
+        Some(ref node) => {
+            let left_count = link_count(&node.left);
+            if n < left_count {
+                return get_nth_r(&node.left, n, path);
+            }
+            n -= left_count;
+            if node.value.is_some() {
+                if n == 0 {
+                    path.push(node.label);
+                    return Some((path, node.value.as_ref().unwrap()));
+                } else {
+                    n -= 1;
+                }
+            }
+            let middle_count = link_count(&node.middle);
+            if n < middle_count {
+                path.push(node.label);
+                return get_nth_r(&node.middle, n, path);
+            }
+            n -= middle_count;
+            get_nth_r(&node.right, n, path)
+        }
+    }
+}
+
 fn get_r_mut<'a, T>(link: &'a mut Link<T>, label: char, key_tail: &mut Chars) -> Option<&'a mut T> {
     match *link {
         None => None,
@@ -967,6 +995,10 @@ impl<T> Tst<T> {
 
             Some(label) => get_r(&self.root, label, &mut key_tail),
         }
+    }
+
+    pub fn get_nth(&self, n: usize) -> Option<(String, &T)> {
+        get_nth_r(&self.root, n, String::new())
     }
 
     /// Returns an mutable reference to the value associated with `key`, or `None`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,13 @@ A Rust implementation of Ternary Search Trees, with no unsafe blocks and a simpl
 https://crates.io/crates/ternary-tree-wasm).
 
 [![Build Status]( http://travis-ci.com/julien-montmartin/ternary-tree.svg?branch=master)](
-	http://travis-ci.com/julien-montmartin/ternary-tree)
+    http://travis-ci.com/julien-montmartin/ternary-tree)
 [![Code coverage]( http://codecov.io/gh/julien-montmartin/ternary-tree/branch/master/graph/badge.svg)](
-	http://codecov.io/gh/julien-montmartin/ternary-tree)
+    http://codecov.io/gh/julien-montmartin/ternary-tree)
 [![Latest version]( http://img.shields.io/crates/v/ternary-tree.svg)](
-	http://crates.io/crates/ternary-tree)
+    http://crates.io/crates/ternary-tree)
 [![API](https://docs.rs/ternary-tree/badge.svg)](
-	https://docs.rs/ternary-tree/)
+    https://docs.rs/ternary-tree/)
 
 A Ternary Search Tree (TST) is a data structure which stores key/value pairs in a tree. The key is a string, and
 its characters are placed in the tree nodes. Each node may have three children (hence the name): a _left_ child, a
@@ -115,16 +115,15 @@ assert_eq!(map.get("cca"), Some(&"xxx"));
 
 #![forbid(unsafe_code)]
 
-use std::str::Chars;
-use std::mem::replace;
-use std::cmp::Ordering::Less;
 use std::cmp::Ordering::Equal;
 use std::cmp::Ordering::Greater;
-use std::io::Write;
-use std::ptr;
+use std::cmp::Ordering::Less;
 use std::fmt;
+use std::io::Write;
 use std::mem;
-
+use std::mem::replace;
+use std::ptr;
+use std::str::Chars;
 
 /// A `Tst` is a ternary tree structure which stores key value pairs and roughly behave like a map, but allowing
 /// more flexible ways to find and iterate over values.
@@ -132,81 +131,66 @@ use std::mem;
 /// See the [module documentation]( ./index.html) for example usage and motivation.
 
 pub struct Tst<T> {
-
     root: Link<T>,
-    count: usize
+    count: usize,
 }
-
 
 type Link<T> = Option<Box<Node<T>>>;
 
-
 struct Node<T> {
-
     label: char,
     value: Option<T>,
     left: Link<T>,
     middle: Link<T>,
-    right: Link<T>
+    right: Link<T>,
 }
 
-
 impl<T> Default for Node<T> {
-
     fn default() -> Node<T> {
-
         Node {
-
             label: '\0',
             value: None,
             left: None,
             middle: None,
-            right: None
+            right: None,
         }
     }
 }
 
-
 impl<T> fmt::Debug for Node<T> {
-
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-
-            let value_box = match self.value {
-
-                None => "☐", Some(_) => "☑"
-            };
+        let value_box = match self.value {
+            None => "☐",
+            Some(_) => "☑",
+        };
 
         write!(f, "{}-{}", value_box, self.label)
     }
 }
 
-
 fn insert_r<T>(link: &mut Link<T>, label: char, mut key_tail: Chars, value: T) -> Option<T> {
-
     let choose_branch_and_do_insert = |node: &mut Box<Node<T>>| match label.cmp(&node.label) {
-
         Less => insert_r(&mut node.left, label, key_tail, value),
 
         Greater => insert_r(&mut node.right, label, key_tail, value),
 
         Equal => {
-
             let new_label = key_tail.next();
 
             match new_label {
-
                 None => replace(&mut node.value, Some(value)),
 
-                Some(label) => insert_r(&mut node.middle, label, key_tail, value)
+                Some(label) => insert_r(&mut node.middle, label, key_tail, value),
             }
         }
     };
 
     match link {
-
         None => {
-
-            let mut node = Box::new(Node::<T>{label, .. Default::default()});
+            let mut node = Box::new(Node::<T> {
+                label,
+                ..Default::default()
+            });
 
             let old_value = choose_branch_and_do_insert(&mut node);
 
@@ -215,167 +199,160 @@ fn insert_r<T>(link: &mut Link<T>, label: char, mut key_tail: Chars, value: T) -
             old_value
         }
 
-        Some(ref mut node) => choose_branch_and_do_insert(node)
+        Some(ref mut node) => choose_branch_and_do_insert(node),
     }
 }
 
-
 fn get_r<'a, T>(link: &'a Link<T>, label: char, key_tail: &mut Chars) -> Option<&'a T> {
-
     match *link {
-
         None => None,
 
         Some(ref node) => match label.cmp(&node.label) {
-
             Less => get_r(&node.left, label, key_tail),
 
             Equal => {
-
                 let new_label = key_tail.next();
 
                 match new_label {
-
                     None => match node.value {
-
                         None => None,
 
-                        Some(ref value) => Some(value)
-                    }
+                        Some(ref value) => Some(value),
+                    },
 
-                    Some(label) => get_r(&node.middle, label, key_tail)
+                    Some(label) => get_r(&node.middle, label, key_tail),
                 }
-            },
+            }
 
             Greater => get_r(&node.right, label, key_tail),
-        }
+        },
     }
 }
 
-
 fn get_r_mut<'a, T>(link: &'a mut Link<T>, label: char, key_tail: &mut Chars) -> Option<&'a mut T> {
-
     match *link {
-
         None => None,
 
         Some(ref mut node) => match label.cmp(&node.label) {
-
             Less => get_r_mut(&mut node.left, label, key_tail),
 
             Equal => {
-
                 let new_label = key_tail.next();
 
                 match new_label {
-
                     None => match node.value {
-
                         None => None,
 
-                        Some(ref mut value) => Some(value)
-                    }
+                        Some(ref mut value) => Some(value),
+                    },
 
-                    Some(label) => get_r_mut(&mut node.middle, label, key_tail)
+                    Some(label) => get_r_mut(&mut node.middle, label, key_tail),
                 }
-            },
+            }
 
             Greater => get_r_mut(&mut node.right, label, key_tail),
-        }
+        },
     }
 }
 
-
 fn remove_r<T>(link: &mut Link<T>, label: char, key_tail: &mut Chars) -> (bool, Option<T>) {
-
     match *link {
-
         None => (false, None),
 
         Some(ref mut node) => match label.cmp(&node.label) {
-
             Less => {
-
                 let (prune, old_value) = remove_r(&mut node.left, label, key_tail);
 
                 if prune {
-
                     node.left = None;
                 }
 
-                let more_pruning = node.value.is_none() && node.left.is_none() && node.middle.is_none() && node.right.is_none();
+                let more_pruning = node.value.is_none()
+                    && node.left.is_none()
+                    && node.middle.is_none()
+                    && node.right.is_none();
                 (more_pruning, old_value)
             }
 
             Equal => {
-
                 let new_label = key_tail.next();
 
                 match new_label {
-
                     None => {
-
                         let old_value = replace(&mut node.value, None);
 
-                        let prune = old_value.is_some() && node.left.is_none() && node.middle.is_none() && node.right.is_none();
+                        let prune = old_value.is_some()
+                            && node.left.is_none()
+                            && node.middle.is_none()
+                            && node.right.is_none();
                         (prune, old_value)
                     }
 
                     Some(label) => {
-
                         let (prune, old_value) = remove_r(&mut node.middle, label, key_tail);
 
                         if prune {
-
                             node.middle = None;
                         }
 
-                        let more_pruning = node.value.is_none() && node.left.is_none() && node.middle.is_none() && node.right.is_none();
+                        let more_pruning = node.value.is_none()
+                            && node.left.is_none()
+                            && node.middle.is_none()
+                            && node.right.is_none();
                         (more_pruning, old_value)
                     }
                 }
             }
 
             Greater => {
-
                 let (prune, old_value) = remove_r(&mut node.right, label, key_tail);
 
                 if prune {
-
                     node.right = None;
                 }
 
-                let more_pruning = node.value.is_none() && node.left.is_none() && node.middle.is_none() && node.right.is_none();
+                let more_pruning = node.value.is_none()
+                    && node.left.is_none()
+                    && node.middle.is_none()
+                    && node.right.is_none();
                 (more_pruning, old_value)
             }
-        }
+        },
     }
 }
 
-
 /// How nodes are distributed. See [Stats]( ./struct.Stats.html) for a brief description.
 
-#[derive(Default,PartialEq,Debug)]
-pub struct DistStat { pub matches: usize, pub sides: usize, pub depth: usize }
-
+#[derive(Default, PartialEq, Debug)]
+pub struct DistStat {
+    pub matches: usize,
+    pub sides: usize,
+    pub depth: usize,
+}
 
 /// How long are the keys. See [Stats]( ./struct.Stats.html) for a brief description.
 
-#[derive(Default,PartialEq,Debug)]
-pub struct KeyLenStat { pub min: usize, pub max: usize }
-
+#[derive(Default, PartialEq, Debug)]
+pub struct KeyLenStat {
+    pub min: usize,
+    pub max: usize,
+}
 
 /// How many nodes and values are in the tree. See [Stats]( ./struct.Stats.html) for a brief description.
 
-#[derive(Default,PartialEq,Debug)]
-pub struct CountStat { pub nodes:usize, pub values: usize }
-
+#[derive(Default, PartialEq, Debug)]
+pub struct CountStat {
+    pub nodes: usize,
+    pub values: usize,
+}
 
 /// Memory used by the tree. See [Stats]( ./struct.Stats.html) for a brief description.
 
-#[derive(Default,PartialEq,Debug)]
-pub struct BytesStat { pub node: usize, pub total: usize }
-
+#[derive(Default, PartialEq, Debug)]
+pub struct BytesStat {
+    pub node: usize,
+    pub total: usize,
+}
 
 /// Contains various metrics describing the tree: its nodes, keys and values. Mostly used for tuning and debugging
 /// purpose.
@@ -392,133 +369,117 @@ pub struct BytesStat { pub node: usize, pub total: usize }
 /// this value)
 /// * `bytes.total` total number of bytes allocated for nodes (`count.nodes` * `bytes.node`)
 
-#[derive(Default,PartialEq,Debug)]
+#[derive(Default, PartialEq, Debug)]
 pub struct Stats {
-
     pub dist: Vec<DistStat>,
     pub key_len: KeyLenStat,
     pub count: CountStat,
     pub bytes: BytesStat,
 }
 
-
 fn stat_r<T>(stats: Stats, link: &Link<T>, matches: usize, sides: usize, depth: usize) -> Stats {
-
     match *link {
-
         None => stats,
 
         Some(ref node) => {
+            let mut stats = stat_r(stats, &node.left, matches, sides + 1, depth + 1);
 
-            let mut stats = stat_r(stats, &node.left, matches, sides+1, depth+1);
-
-            stats.count.nodes+=1;
+            stats.count.nodes += 1;
 
             if node.value.is_some() {
-
                 let matches = matches + 1;
                 let depth = depth + 1;
 
                 while stats.dist.len() <= depth {
-
-                    stats.dist.push(DistStat { matches: 0, sides: 0, depth: 0 });
+                    stats.dist.push(DistStat {
+                        matches: 0,
+                        sides: 0,
+                        depth: 0,
+                    });
                 }
 
-                stats.dist[matches].matches+=1;
-                stats.dist[sides].sides+=1;
-                stats.dist[depth].depth+=1;
+                stats.dist[matches].matches += 1;
+                stats.dist[sides].sides += 1;
+                stats.dist[depth].depth += 1;
 
                 if stats.key_len.min == 0 || matches < stats.key_len.min {
-
                     stats.key_len.min = matches;
                 }
 
                 if matches > stats.key_len.max {
-
                     stats.key_len.max = matches;
                 }
 
-                stats.count.values+=1;
+                stats.count.values += 1;
             }
 
-            let stats = stat_r(stats, &node.middle, matches+1, sides, depth+1);
-            let stats = stat_r(stats, &node.right, matches, sides+1, depth+1);
+            let stats = stat_r(stats, &node.middle, matches + 1, sides, depth + 1);
+            let stats = stat_r(stats, &node.right, matches, sides + 1, depth + 1);
 
             stats
         }
     }
 }
 
-
 fn find_complete_root_r<'a, T>(link: &'a Link<T>, label: char, mut key_tail: Chars) -> &'a Link<T> {
-
     match *link {
-
         None => &link,
 
         Some(ref node) => match label.cmp(&node.label) {
-
             Less => find_complete_root_r(&node.left, label, key_tail),
 
             Greater => find_complete_root_r(&node.right, label, key_tail),
 
             Equal => {
-
                 let new_label = key_tail.next();
 
                 match new_label {
-
                     None => &node.middle,
 
-                    Some(label) => find_complete_root_r(&node.middle, label, key_tail)
+                    Some(label) => find_complete_root_r(&node.middle, label, key_tail),
                 }
             }
-        }
+        },
     }
 }
 
-
-fn find_complete_root_r_mut<'a, T>(link: &'a mut Link<T>, label: char, mut key_tail: Chars) -> &'a mut Link<T> {
-
+fn find_complete_root_r_mut<'a, T>(
+    link: &'a mut Link<T>,
+    label: char,
+    mut key_tail: Chars,
+) -> &'a mut Link<T> {
     match *link {
-
-        None => { link }
+        None => link,
 
         Some(ref mut node) => match label.cmp(&node.label) {
-
             Less => find_complete_root_r_mut(&mut node.left, label, key_tail),
 
             Greater => find_complete_root_r_mut(&mut node.right, label, key_tail),
 
             Equal => {
-
                 let new_label = key_tail.next();
 
                 match new_label {
-
                     None => &mut node.middle,
 
-                    Some(label) => find_complete_root_r_mut(&mut node.middle, label, key_tail)
+                    Some(label) => find_complete_root_r_mut(&mut node.middle, label, key_tail),
                 }
             }
-        }
+        },
     }
 }
-
 
 fn visit_values_r<T, C>(link: &Link<T>, callback: &mut C)
-where C: FnMut (&T) {
-
+where
+    C: FnMut(&T),
+{
     match *link {
-
         None => return,
 
         Some(ref node) => {
-
             visit_values_r(&node.left, callback);
 
             if let Some(ref value) = node.value {
-
                 callback(value);
             }
 
@@ -527,21 +488,18 @@ where C: FnMut (&T) {
         }
     }
 }
-
 
 fn visit_values_r_mut<T, C>(link: &mut Link<T>, callback: &mut C)
-where C: FnMut (&mut T) {
-
+where
+    C: FnMut(&mut T),
+{
     match *link {
-
         None => return,
 
         Some(ref mut node) => {
-
             visit_values_r_mut(&mut node.left, callback);
 
             if let Some(ref mut value) = node.value {
-
                 callback(value);
             }
 
@@ -551,20 +509,17 @@ where C: FnMut (&mut T) {
     }
 }
 
-
 fn visit_complete_values_r<T, C>(link: &Link<T>, callback: &mut C)
-where C: FnMut (&T) {
-
+where
+    C: FnMut(&T),
+{
     match *link {
-
         None => return,
 
         Some(ref node) => {
-
             visit_values_r(&node.left, callback);
 
             if let Some(ref value) = node.value {
-
                 callback(value);
             }
 
@@ -574,20 +529,17 @@ where C: FnMut (&T) {
     }
 }
 
-
 fn visit_complete_values_r_mut<T, C>(link: &mut Link<T>, callback: &mut C)
-where C: FnMut (&mut T) {
-
+where
+    C: FnMut(&mut T),
+{
     match *link {
-
         None => return,
 
         Some(ref mut node) => {
-
             visit_values_r_mut(&mut node.left, callback);
 
             if let Some(ref mut value) = node.value {
-
                 callback(value);
             }
 
@@ -597,55 +549,70 @@ where C: FnMut (&mut T) {
     }
 }
 
-
-fn visit_neighbor_values_r<'a, T, C>(link: &'a Link<T>, label: Option<char>, key_tail: &mut Chars, tail_len: usize, range: usize, callback: &mut C)
-where C: FnMut (&T) {
-
+fn visit_neighbor_values_r<'a, T, C>(
+    link: &'a Link<T>,
+    label: Option<char>,
+    key_tail: &mut Chars,
+    tail_len: usize,
+    range: usize,
+    callback: &mut C,
+) where
+    C: FnMut(&T),
+{
     if range == 0 {
-
         if let Some(label) = label {
-
             if let Some(value) = get_r(link, label, key_tail) {
-
                 callback(value);
             }
         }
-
     } else {
-
         if let Some(ref node) = *link {
-
             visit_neighbor_values_r(&node.left, label, key_tail, tail_len, range, callback);
 
             if let Some(ref value) = node.value {
-
                 let new_range = match label {
+                    None => range - 1,
 
-                    None => range-1,
-
-                    Some(label) => if label==node.label { range } else { range-1 }
+                    Some(label) => {
+                        if label == node.label {
+                            range
+                        } else {
+                            range - 1
+                        }
+                    }
                 };
 
                 if tail_len <= new_range {
-
                     callback(value);
                 }
             }
 
             {
                 let new_range = match label {
+                    None => range - 1,
 
-                    None => range-1,
-
-                    Some(label) => if label==node.label { range } else { range-1 }
+                    Some(label) => {
+                        if label == node.label {
+                            range
+                        } else {
+                            range - 1
+                        }
+                    }
                 };
 
                 let mut new_tail = key_tail.clone();
                 let new_label = new_tail.next();
 
-                let new_len = if tail_len > 0 { tail_len-1 } else { tail_len };
+                let new_len = if tail_len > 0 { tail_len - 1 } else { tail_len };
 
-                visit_neighbor_values_r(&node.middle, new_label, &mut new_tail, new_len, new_range, callback);
+                visit_neighbor_values_r(
+                    &node.middle,
+                    new_label,
+                    &mut new_tail,
+                    new_len,
+                    new_range,
+                    callback,
+                );
             }
 
             visit_neighbor_values_r(&node.right, label, key_tail, tail_len, range, callback);
@@ -653,186 +620,226 @@ where C: FnMut (&T) {
     }
 }
 
-
-fn visit_neighbor_values_r_mut<'a, T, C>(link: &'a mut Link<T>, label: Option<char>, key_tail: &mut Chars, tail_len: usize, range: usize, callback: &mut C)
-where C: FnMut (&mut T) {
-
+fn visit_neighbor_values_r_mut<'a, T, C>(
+    link: &'a mut Link<T>,
+    label: Option<char>,
+    key_tail: &mut Chars,
+    tail_len: usize,
+    range: usize,
+    callback: &mut C,
+) where
+    C: FnMut(&mut T),
+{
     if range == 0 {
-
         if let Some(label) = label {
-
             if let Some(value) = get_r_mut(link, label, key_tail) {
-
                 callback(value);
             }
         }
-
     } else {
-
         if let Some(ref mut node) = *link {
-
             let label_tmp = node.label;
 
             visit_neighbor_values_r_mut(&mut node.left, label, key_tail, tail_len, range, callback);
 
             if let Some(ref mut value) = node.value {
-
                 let new_range = match label {
+                    None => range - 1,
 
-                    None => range-1,
-
-                    Some(label) => if label == label_tmp { range } else { range-1 }
+                    Some(label) => {
+                        if label == label_tmp {
+                            range
+                        } else {
+                            range - 1
+                        }
+                    }
                 };
 
                 if tail_len <= new_range {
-
                     callback(value);
                 }
             }
 
             {
                 let new_range = match label {
+                    None => range - 1,
 
-                    None => range-1,
-
-                    Some(label) => if label == node.label { range } else { range-1 }
+                    Some(label) => {
+                        if label == node.label {
+                            range
+                        } else {
+                            range - 1
+                        }
+                    }
                 };
 
                 let mut new_tail = key_tail.clone();
                 let new_label = new_tail.next();
 
-                let new_len = if tail_len > 0 { tail_len-1 } else { tail_len };
+                let new_len = if tail_len > 0 { tail_len - 1 } else { tail_len };
 
-                visit_neighbor_values_r_mut(&mut node.middle, new_label, &mut new_tail, new_len, new_range, callback);
+                visit_neighbor_values_r_mut(
+                    &mut node.middle,
+                    new_label,
+                    &mut new_tail,
+                    new_len,
+                    new_range,
+                    callback,
+                );
             }
 
-            visit_neighbor_values_r_mut(&mut node.right, label, key_tail, tail_len, range, callback);
+            visit_neighbor_values_r_mut(
+                &mut node.right,
+                label,
+                key_tail,
+                tail_len,
+                range,
+                callback,
+            );
         }
     }
 }
 
-
-fn visit_crossword_values_r<'a, T, C>(link: &'a Link<T>, label: char, key_tail: &mut Chars, joker: char, callback: &mut C)
-    where C: FnMut (&T) {
-
+fn visit_crossword_values_r<'a, T, C>(
+    link: &'a Link<T>,
+    label: char,
+    key_tail: &mut Chars,
+    joker: char,
+    callback: &mut C,
+) where
+    C: FnMut(&T),
+{
     match *link {
-
         None => return,
 
         Some(ref node) => {
-
             if label == joker || label < node.label {
-
                 visit_crossword_values_r(&node.left, label, key_tail, joker, callback);
             }
 
             if label == joker || label == node.label {
-
                 let mut new_tail = key_tail.clone();
                 let new_label = new_tail.next();
 
                 match new_label {
+                    None => {
+                        if let Some(ref value) = node.value {
+                            callback(value);
+                        }
+                    }
 
-                    None =>  if let Some(ref value) = node.value {
-
-                        callback(value);
-                    },
-
-                    Some(label) => visit_crossword_values_r(&node.middle, label, &mut new_tail, joker, callback)
+                    Some(label) => visit_crossword_values_r(
+                        &node.middle,
+                        label,
+                        &mut new_tail,
+                        joker,
+                        callback,
+                    ),
                 }
             }
 
             if label == joker || label > node.label {
-
                 visit_crossword_values_r(&node.right, label, key_tail, joker, callback);
             }
         }
     }
 }
 
-
-fn visit_crossword_values_r_mut<'a, T, C>(link: &'a mut Link<T>, label: char, key_tail: &mut Chars, joker: char, callback: &mut C)
-    where C: FnMut (&mut T) {
-
+fn visit_crossword_values_r_mut<'a, T, C>(
+    link: &'a mut Link<T>,
+    label: char,
+    key_tail: &mut Chars,
+    joker: char,
+    callback: &mut C,
+) where
+    C: FnMut(&mut T),
+{
     match *link {
-
         None => return,
 
         Some(ref mut node) => {
-
             if label == joker || label < node.label {
-
                 visit_crossword_values_r_mut(&mut node.left, label, key_tail, joker, callback);
             }
 
             if label == joker || label == node.label {
-
                 let mut new_tail = key_tail.clone();
                 let new_label = new_tail.next();
 
                 match new_label {
+                    None => {
+                        if let Some(ref mut value) = node.value {
+                            callback(value);
+                        }
+                    }
 
-                    None =>  if let Some(ref mut value) = node.value {
-
-                        callback(value);
-                    },
-
-                    Some(label) => visit_crossword_values_r_mut(&mut node.middle, label, &mut new_tail, joker, callback)
+                    Some(label) => visit_crossword_values_r_mut(
+                        &mut node.middle,
+                        label,
+                        &mut new_tail,
+                        joker,
+                        callback,
+                    ),
                 }
             }
 
             if label == joker || label > node.label {
-
                 visit_crossword_values_r_mut(&mut node.right, label, key_tail, joker, callback);
             }
         }
     }
 }
 
-
 fn pretty_print_r<'a, T>(link: &'a Link<T>, ids: &mut Tst<usize>, writer: &mut dyn Write) {
-
     match *link {
-
         None => return,
 
         Some(ref node) => {
-
             let value_box = match node.value {
-
-                None => "☐", Some(_) => "☑"
+                None => "☐",
+                Some(_) => "☑",
             };
 
             {
                 let mut get_id = |node: &Box<Node<T>>| {
-
                     let node_addr = format!("{:p}", node);
 
                     let prev_id = match ids.get(&node_addr) {
-
                         None => None,
 
-                        Some(id) => Some(*id)
+                        Some(id) => Some(*id),
                     };
 
                     match prev_id {
-
                         None => {
-
                             let id = ids.len();
                             ids.insert(&node_addr, id);
                             id
                         }
 
-                        Some(id) => id
+                        Some(id) => id,
                     }
                 };
 
-                let _ = writeln!(writer, r#"N{} [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0"><TR><TD COLSPAN="3">{} {}</TD></TR><TR><TD PORT="l"></TD><TD PORT="m"></TD><TD PORT="r"></TD></TR></TABLE>>]"#, get_id(node), value_box, node.label);
+                let _ = writeln!(
+                    writer,
+                    r#"N{} [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0"><TR><TD COLSPAN="3">{} {}</TD></TR><TR><TD PORT="l"></TD><TD PORT="m"></TD><TD PORT="r"></TD></TR></TABLE>>]"#,
+                    get_id(node),
+                    value_box,
+                    node.label
+                );
 
-                let mut print_edge = |link, start, style| if let &Some(ref child) = link {
-
-                    let _ = writeln!(writer, r#"N{}:{} -> N{} [style={}]"#, get_id(node), start, get_id(child), style);
+                let mut print_edge = |link, start, style| {
+                    if let &Some(ref child) = link {
+                        let _ = writeln!(
+                            writer,
+                            r#"N{}:{} -> N{} [style={}]"#,
+                            get_id(node),
+                            start,
+                            get_id(child),
+                            style
+                        );
+                    }
                 };
 
                 print_edge(&node.left, "l", "solid");
@@ -847,9 +854,7 @@ fn pretty_print_r<'a, T>(link: &'a Link<T>, ids: &mut Tst<usize>, writer: &mut d
     }
 }
 
-
 impl<T> Tst<T> {
-
     /// Create a new, empty `Tst`. The key is always a string slice and one needs only to provide a value
     /// type. The following code creates an empty tree which stores `bool` values
     ///
@@ -868,10 +873,11 @@ impl<T> Tst<T> {
     /// And the exact value type is properly guessed.
 
     pub fn new() -> Self {
-
-        Tst { root: None, count: 0 }
+        Tst {
+            root: None,
+            count: 0,
+        }
     }
-
 
     /// Inserts `key` and `value` pair in the tree, returning any value previously associated with `key`.
     ///
@@ -903,19 +909,15 @@ impl<T> Tst<T> {
     /// insertion is done, `key` is given back to the caller.
 
     pub fn insert(&mut self, key: &str, value: T) -> Option<T> {
-
         let mut key_tail = key.chars();
 
         match key_tail.next() {
-
             None => Some(value),
 
             Some(label) => {
-
                 let old_value = insert_r(&mut self.root, label, key_tail, value);
 
                 if old_value.is_none() {
-
                     self.count += 1;
                 }
 
@@ -923,7 +925,6 @@ impl<T> Tst<T> {
             }
         }
     }
-
 
     /// Returns an immutable reference to the value associated with `key`, or None.
     ///
@@ -936,17 +937,14 @@ impl<T> Tst<T> {
     /// assert_eq!(v, Some(&"🍄🍄"));
 
     pub fn get(&self, key: &str) -> Option<&T> {
-
         let mut key_tail = key.chars();
 
         match key_tail.next() {
-
             None => None,
 
-            Some(label) => get_r(&self.root, label, &mut key_tail)
+            Some(label) => get_r(&self.root, label, &mut key_tail),
         }
     }
-
 
     /// Returns an mutable reference to the value associated with `key`, or `None`.
     ///
@@ -963,17 +961,14 @@ impl<T> Tst<T> {
     /// assert_eq!(v, Some(&"🍄🍄".to_string()));
 
     pub fn get_mut(&mut self, key: &str) -> Option<&mut T> {
-
         let mut key_tail = key.chars();
 
         match key_tail.next() {
-
             None => None,
 
-            Some(label) => get_r_mut(&mut self.root, label, &mut key_tail)
+            Some(label) => get_r_mut(&mut self.root, label, &mut key_tail),
         }
     }
-
 
     /// Removes the value associated with `key` from the tree, and returns it. Does nothing if no value is
     /// associated with `key`, and returns `None`.
@@ -990,29 +985,24 @@ impl<T> Tst<T> {
     /// assert_eq!(v, None);
 
     pub fn remove(&mut self, key: &str) -> Option<T> {
-
         let mut key_tail = key.chars();
 
         let (prune, old_value) = match key_tail.next() {
-
             None => (false, None),
 
-            Some(label) => remove_r(&mut self.root, label, &mut key_tail)
+            Some(label) => remove_r(&mut self.root, label, &mut key_tail),
         };
 
         if prune {
-
             self.root = None;
         }
 
         if old_value.is_some() {
-
             self.count -= 1;
         }
 
         old_value
     }
-
 
     /// Returns the number of values stored in the tree.
     ///
@@ -1026,10 +1016,8 @@ impl<T> Tst<T> {
     /// ```
 
     pub fn len(&self) -> usize {
-
         self.count
     }
-
 
     /// Walks the tree, gathers various metrics about nodes, keys and values, and returns a [`Stats`](
     /// ./struct.Stats.html) structure to sum it up.
@@ -1049,17 +1037,15 @@ impl<T> Tst<T> {
     /// See [Stats]( ./struct.Stats.html) for a detailed description of available fields.
 
     pub fn stat(&self) -> Stats {
-
         let empty_stats: Stats = Default::default();
 
         let mut stats = stat_r(empty_stats, &self.root, 0, 0, 0);
 
         stats.bytes.node = mem::size_of::<Node<T>>();
-        stats.bytes.total = mem::size_of::<Tst<T>>()+stats.count.nodes*stats.bytes.node;
+        stats.bytes.total = mem::size_of::<Tst<T>>() + stats.count.nodes * stats.bytes.node;
 
         stats
     }
-
 
     /// Deletes every node and value stored in the tree.
     ///
@@ -1075,11 +1061,9 @@ impl<T> Tst<T> {
     /// assert_eq!(map.len(), 0);
 
     pub fn clear(&mut self) {
-
         self.root = None;
         self.count = 0;
     }
-
 
     /// Recursively walks the tree and calls `callback` closure on each immutable value. Values are found in
     /// alphabetical order of keys. See also the [`iter`]( ./struct.Tst.html#method.iter) method which produces the
@@ -1096,22 +1080,22 @@ impl<T> Tst<T> {
     /// ```
 
     pub fn visit_values<C>(&self, mut callback: C)
-    where C: FnMut (&T) {
-
+    where
+        C: FnMut(&T),
+    {
         visit_values_r(&self.root, &mut callback);
     }
-
 
     /// Recursively walks the tree and calls `callback` closure on each mutable value. The same as
     /// [`visit_values`]( ./struct.Tst.html#method.visit_values), except the `_mut` version works on mutable
     /// values, and does not have an iterator counterpart.
 
     pub fn visit_values_mut<C>(&mut self, mut callback: C)
-    where C: FnMut (&mut T) {
-
+    where
+        C: FnMut(&mut T),
+    {
         visit_values_r_mut(&mut self.root, &mut callback);
     }
-
 
     /// Recursively walks the tree and calls `callback` closure on each immutable value whose key begins with
     /// `key_prefix`. Values are found in alphabetical order of keys. See also the [`iter_complete`](
@@ -1144,44 +1128,40 @@ impl<T> Tst<T> {
     /// ./struct.Tst.html#method.visit_values), and all values stored in the tree are found.
 
     pub fn visit_complete_values<C>(&self, key_prefix: &str, mut callback: C)
-    where C: FnMut (&T) {
-
+    where
+        C: FnMut(&T),
+    {
         let mut prefix_tail = key_prefix.chars();
 
         match prefix_tail.next() {
-
             None => visit_values_r(&self.root, &mut callback),
 
             Some(label) => {
-
                 let new_root = find_complete_root_r(&self.root, label, prefix_tail);
                 visit_complete_values_r(new_root, &mut callback)
             }
         }
     }
 
-
     /// Recursively walks the tree and calls `callback` closure on each mutable value whose key begins with
     /// `key_prefix`. The same as [`visit_complete_values`]( ./struct.Tst.html#method.visit_complete_values),
     /// except the `_mut` version works on mutable values, and does not have an iterator counterpart.
 
     pub fn visit_complete_values_mut<C>(&mut self, key_prefix: &str, mut callback: C)
-    where C: FnMut (&mut T) {
-
+    where
+        C: FnMut(&mut T),
+    {
         let mut prefix_tail = key_prefix.chars();
 
         match prefix_tail.next() {
-
             None => visit_values_r_mut(&mut self.root, &mut callback),
 
             Some(label) => {
-
                 let mut new_root = find_complete_root_r_mut(&mut self.root, label, prefix_tail);
                 visit_complete_values_r_mut(&mut new_root, &mut callback)
             }
         }
     }
-
 
     /// Recursively walks the tree and calls `callback` closure on each immutable value whose key is _close_ to
     /// `key`. A key is considered _close_ to `key` within a [Hamming distance](
@@ -1214,16 +1194,23 @@ impl<T> Tst<T> {
     /// ```
 
     pub fn visit_neighbor_values<C>(&self, key: &str, range: usize, mut callback: C)
-    where C: FnMut (&T) {
-
+    where
+        C: FnMut(&T),
+    {
         let mut key_tail = key.chars();
         let key_len = key.chars().count();
         let label = key_tail.next();
-        let tail_len = if key_len == 0 { 0 } else { key_len-1 };
+        let tail_len = if key_len == 0 { 0 } else { key_len - 1 };
 
-        visit_neighbor_values_r(&self.root, label, &mut key_tail, tail_len, range, &mut callback);
+        visit_neighbor_values_r(
+            &self.root,
+            label,
+            &mut key_tail,
+            tail_len,
+            range,
+            &mut callback,
+        );
     }
-
 
     /// Recursively walks the tree and calls `callback` closure on each mutable value whose key is _close_ to `key`
     /// ([Hamming distance]( http://en.wikipedia.org/wiki/Hamming_distance) of `range`). The same as
@@ -1231,16 +1218,23 @@ impl<T> Tst<T> {
     /// on mutable values, and does not have an iterator counterpart.
 
     pub fn visit_neighbor_values_mut<C>(&mut self, key: &str, range: usize, mut callback: C)
-    where C: FnMut (&mut T) {
-
+    where
+        C: FnMut(&mut T),
+    {
         let mut key_tail = key.chars();
         let key_len = key.chars().count();
         let label = key_tail.next();
-        let tail_len = if key_len == 0 { 0 } else { key_len-1 };
+        let tail_len = if key_len == 0 { 0 } else { key_len - 1 };
 
-        visit_neighbor_values_r_mut(&mut self.root, label, &mut key_tail, tail_len, range, &mut callback);
+        visit_neighbor_values_r_mut(
+            &mut self.root,
+            label,
+            &mut key_tail,
+            tail_len,
+            range,
+            &mut callback,
+        );
     }
-
 
     /// Recursively walks the tree and calls `callback` closure on each immutable value whose key _matches_
     /// `pattern`. The `pattern` is a string slice where each `joker` character stands for _any_ character. Values
@@ -1273,18 +1267,19 @@ impl<T> Tst<T> {
     /// An empty `pattern` is meaningless, and does not find any value.
 
     pub fn visit_crossword_values<C>(&self, pattern: &str, joker: char, mut callback: C)
-    where C: FnMut (&T) {
-
+    where
+        C: FnMut(&T),
+    {
         let mut pattern_tail = pattern.chars();
 
         match pattern_tail.next() {
-
             None => return,
 
-            Some(label) => visit_crossword_values_r(&self.root, label, &mut pattern_tail, joker, &mut callback)
+            Some(label) => {
+                visit_crossword_values_r(&self.root, label, &mut pattern_tail, joker, &mut callback)
+            }
         }
     }
-
 
     /// Recursively walks the tree and calls `callback` closure on each mutable value whose key _matches_ `pattern`
     /// with `joker` characters. The same as [`visit_crossword_values`](
@@ -1292,18 +1287,23 @@ impl<T> Tst<T> {
     /// does not have an iterator counterpart.
 
     pub fn visit_crossword_values_mut<C>(&mut self, pattern: &str, joker: char, mut callback: C)
-    where C: FnMut (&mut T) {
-
+    where
+        C: FnMut(&mut T),
+    {
         let mut pattern_tail = pattern.chars();
 
         match pattern_tail.next() {
-
             None => return,
 
-            Some(label) => visit_crossword_values_r_mut(&mut self.root, label, &mut pattern_tail, joker, &mut callback)
+            Some(label) => visit_crossword_values_r_mut(
+                &mut self.root,
+                label,
+                &mut pattern_tail,
+                joker,
+                &mut callback,
+            ),
         }
     }
-
 
     /// Dump the tree in `writer` using the _dot_ language of [Graphviz]( http://www.graphviz.org) tools. A checked
     /// box "☑" denotes a node which stores a value (it corresponds to the last character of a key). An empty box
@@ -1311,7 +1311,6 @@ impl<T> Tst<T> {
     /// documentation]( ./index.html) for an example.
 
     pub fn pretty_print(&self, writer: &mut dyn Write) {
-
         let _ = writeln!(writer, "digraph {{");
         let _ = writeln!(writer, "node [shape=plaintext]");
 
@@ -1321,7 +1320,6 @@ impl<T> Tst<T> {
 
         let _ = writeln!(writer, "}}");
     }
-
 
     /// Create a [double-ended]( http://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html) iterator which
     /// successively returns all values of the tree. Values are immutable, and are found in alphabetical order of
@@ -1351,10 +1349,8 @@ impl<T> Tst<T> {
     /// ```
 
     pub fn iter(&self) -> TstIterator<T> {
-
         TstIterator::<T>::new(&self)
     }
-
 
     /// Create a [double-ended]( http://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html) iterator which
     /// successively returns all values whose key begins with `prefix`. Values are immutable, and are found in
@@ -1385,10 +1381,8 @@ impl<T> Tst<T> {
     /// ```
 
     pub fn iter_complete(&self, prefix: &str) -> TstCompleteIterator<T> {
-
         TstCompleteIterator::<T>::new(&self, prefix)
     }
-
 
     /// Create a [double-ended]( http://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html) iterator which
     /// successively returns all values whose key is _close_ to `key`. A key is considered _close_ to `key` within
@@ -1421,11 +1415,13 @@ impl<T> Tst<T> {
     /// assert_eq!((last_key, last_value), ("baz".to_string(), Some(&"㵅")));
     /// ```
 
-    pub fn iter_neighbor<'a, 'b>(&'a self, key: &'b str, range: usize) -> TstNeighborIterator<'a, 'b, T> {
-
+    pub fn iter_neighbor<'a, 'b>(
+        &'a self,
+        key: &'b str,
+        range: usize,
+    ) -> TstNeighborIterator<'a, 'b, T> {
         TstNeighborIterator::<T>::new(&self, key, range)
     }
-
 
     /// Create a [double-ended]( http://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html) iterator which
     /// successively returns all values whose key _matches_ `pattern`. The `pattern` is a string slice where each
@@ -1457,12 +1453,14 @@ impl<T> Tst<T> {
     /// assert_eq!((last_key, last_value), ("baz".to_string(), Some(&"㵅")));
     /// ```
 
-    pub fn iter_crossword<'a, 'b>(&'a self, pattern: &'b str, joker: char) -> TstCrosswordIterator<'a, 'b, T> {
-
+    pub fn iter_crossword<'a, 'b>(
+        &'a self,
+        pattern: &'b str,
+        joker: char,
+    ) -> TstCrosswordIterator<'a, 'b, T> {
         TstCrosswordIterator::<T>::new(&self, pattern, joker)
     }
 }
-
 
 /// A shortcut macro to help create a small tree with a list of known `"key" => value` pairs. Calls [`insert`](
 /// ./struct.Tst.html#method.insert) on each pair, in order.
@@ -1494,18 +1492,15 @@ macro_rules! tst {
     }};
 }
 
-
 #[derive(Debug, PartialEq)]
 enum TstIteratorAction {
-
     GoLeft,
     Visit,
     GoMiddle,
-    GoRight
+    GoRight,
 }
 
 use self::TstIteratorAction::*;
-
 
 /// A [double-ended]( http://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html) iterator which
 /// successively returns all values of the tree. See [`iter`]( struct.Tst.html#method.iter) method for a brief
@@ -1513,55 +1508,43 @@ use self::TstIteratorAction::*;
 
 #[derive(Debug)]
 pub struct TstIterator<'a, T: 'a> {
-
     todo_i: Vec<(&'a Node<T>, TstIteratorAction)>,
     last_i: Option<&'a Node<T>>,
 
     todo_j: Vec<(&'a Node<T>, TstIteratorAction)>,
-    last_j: Option<&'a Node<T>>
+    last_j: Option<&'a Node<T>>,
 }
 
-
 macro_rules! gen_it_path {
-
-    ($path_of_x:ident, $todo_x:ident, $a1:expr, $a2:expr) => (
-
+    ($path_of_x:ident, $todo_x:ident, $a1:expr, $a2:expr) => {
         pub fn $path_of_x(&self) -> String {
-
             let mut path = String::new();
 
             for todo in self.$todo_x.iter() {
-
                 if todo.1 == $a1 || todo.1 == $a2 {
-
                     path.push(todo.0.label);
                 }
             }
 
             path
         }
-    );
+    };
 }
 
-
 impl<'a, T> TstIterator<'a, T> {
-
     pub fn new(tst: &'a Tst<T>) -> Self {
-
         TstIterator::new_from_root(&tst.root)
     }
 
-
     fn new_from_root(root: &'a Link<T>) -> Self {
-
         let mut it = TstIterator {
-
-            todo_i: Vec::new(), last_i: None,
-            todo_j: Vec::new(), last_j: None,
+            todo_i: Vec::new(),
+            last_i: None,
+            todo_j: Vec::new(),
+            last_j: None,
         };
 
         if let Some(ref node) = root {
-
             it.todo_i.push((node, GoLeft));
             it.todo_j.push((node, GoRight));
         }
@@ -1569,42 +1552,30 @@ impl<'a, T> TstIterator<'a, T> {
         it
     }
 
-
     gen_it_path!(current_key, todo_i, GoMiddle, GoRight);
     gen_it_path!(current_key_back, todo_j, Visit, GoLeft);
 }
 
-
 impl<'a, T> Iterator for TstIterator<'a, T> {
-
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
-
         let mut found = None;
 
         while let Some((node, action)) = self.todo_i.pop() {
-
             match action {
-
                 GoLeft => {
-
                     self.todo_i.push((node, Visit));
 
                     if let Some(ref child) = node.left {
-
                         self.todo_i.push((child, GoLeft));
                     }
                 }
 
                 Visit => {
-
                     if node.value.is_some() {
-
                         if let Some(node_j) = self.last_j {
-
                             if ptr::eq(node, node_j) {
-
                                 self.todo_i.clear();
                                 self.todo_j.clear();
 
@@ -1617,7 +1588,6 @@ impl<'a, T> Iterator for TstIterator<'a, T> {
                     self.todo_i.push((node, GoMiddle));
 
                     if let Some(ref value) = node.value {
-
                         self.last_i = Some(node);
                         found = Some(value);
 
@@ -1626,19 +1596,15 @@ impl<'a, T> Iterator for TstIterator<'a, T> {
                 }
 
                 GoMiddle => {
-
                     self.todo_i.push((node, GoRight));
 
                     if let Some(ref child) = node.middle {
-
                         self.todo_i.push((child, GoLeft));
                     }
                 }
 
                 GoRight => {
-
                     if let Some(ref child) = node.right {
-
                         self.todo_i.push((child, GoLeft));
                     }
                 }
@@ -1649,47 +1615,33 @@ impl<'a, T> Iterator for TstIterator<'a, T> {
     }
 }
 
-
 impl<'a, T> IntoIterator for &'a Tst<T> {
-
     type Item = &'a T;
     type IntoIter = TstIterator<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
-
         self.iter()
     }
 }
 
-
 impl<'a, T> DoubleEndedIterator for TstIterator<'a, T> {
-
     fn next_back(&mut self) -> Option<&'a T> {
-
         let mut found = None;
 
         while let Some((node, action)) = self.todo_j.pop() {
-
             match action {
-
                 GoRight => {
-
                     self.todo_j.push((node, GoMiddle));
 
                     if let Some(ref child) = node.right {
-
                         self.todo_j.push((child, GoRight));
                     }
                 }
 
                 Visit => {
-
                     if node.value.is_some() {
-
                         if let Some(node_i) = self.last_i {
-
                             if ptr::eq(node, node_i) {
-
                                 self.todo_i.clear();
                                 self.todo_j.clear();
 
@@ -1702,7 +1654,6 @@ impl<'a, T> DoubleEndedIterator for TstIterator<'a, T> {
                     self.todo_j.push((node, GoLeft));
 
                     if let Some(ref value) = node.value {
-
                         self.last_j = Some(node);
                         found = Some(value);
 
@@ -1711,19 +1662,15 @@ impl<'a, T> DoubleEndedIterator for TstIterator<'a, T> {
                 }
 
                 GoMiddle => {
-
                     self.todo_j.push((node, Visit));
 
                     if let Some(ref child) = node.middle {
-
                         self.todo_j.push((child, GoRight));
                     }
                 }
 
                 GoLeft => {
-
                     if let Some(ref child) = node.left {
-
                         self.todo_j.push((child, GoRight));
                     }
                 }
@@ -1734,75 +1681,56 @@ impl<'a, T> DoubleEndedIterator for TstIterator<'a, T> {
     }
 }
 
-
 /// A [double-ended]( http://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html) iterator which
 /// successively returns all values whose key begins with `prefix`. See [`iter_complete`](
 /// struct.Tst.html#method.iter_complete) method for a brief description with a short example.
 
 #[derive(Debug)]
 pub struct TstCompleteIterator<'a, T: 'a> {
-
     it: TstIterator<'a, T>,
-    prefix: String
+    prefix: String,
 }
 
-
 impl<'a, T> TstCompleteIterator<'a, T> {
-
     pub fn new(tst: &'a Tst<T>, key_prefix: &str) -> Self {
-
         let mut key_tail = key_prefix.chars();
 
         TstCompleteIterator {
-
-            it : match key_tail.next() {
-
+            it: match key_tail.next() {
                 None => TstIterator::<T>::new(tst),
 
                 Some(label) => {
-
                     let new_root = find_complete_root_r(&tst.root, label, key_tail);
                     TstIterator::<T>::new_from_root(new_root)
                 }
             },
 
-            prefix: key_prefix.to_string()
+            prefix: key_prefix.to_string(),
         }
     }
 
-
     pub fn current_key(&self) -> String {
-
         self.prefix.clone() + &self.it.current_key()
     }
 
-
     pub fn current_key_back(&self) -> String {
-
         self.prefix.clone() + &self.it.current_key_back()
     }
 }
 
-
 impl<'a, T> Iterator for TstCompleteIterator<'a, T> {
-
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
-
         self.it.next()
     }
 }
 
-
 impl<'a, T> DoubleEndedIterator for TstCompleteIterator<'a, T> {
-
     fn next_back(&mut self) -> Option<&'a T> {
-
-       self.it.next_back()
+        self.it.next_back()
     }
 }
-
 
 /// A [double-ended]( http://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html) iterator which
 /// successively returns all values whose key is _close_ to `key`. See [`iter_neighbor`](
@@ -1810,83 +1738,83 @@ impl<'a, T> DoubleEndedIterator for TstCompleteIterator<'a, T> {
 
 #[derive(Debug)]
 pub struct TstNeighborIterator<'a, 'b, T: 'a> {
-
-    todo_i: Vec<(&'a Node<T>, TstIteratorAction, Option<char>, Chars<'b>, usize, usize)>,
+    todo_i: Vec<(
+        &'a Node<T>,
+        TstIteratorAction,
+        Option<char>,
+        Chars<'b>,
+        usize,
+        usize,
+    )>,
     last_i: Option<&'a Node<T>>,
 
-    todo_j: Vec<(&'a Node<T>, TstIteratorAction, Option<char>, Chars<'b>, usize, usize)>,
-    last_j: Option<&'a Node<T>>
+    todo_j: Vec<(
+        &'a Node<T>,
+        TstIteratorAction,
+        Option<char>,
+        Chars<'b>,
+        usize,
+        usize,
+    )>,
+    last_j: Option<&'a Node<T>>,
 }
 
-
 impl<'a, 'b, T> TstNeighborIterator<'a, 'b, T> {
-
     pub fn new(tst: &'a Tst<T>, key: &'b str, range: usize) -> Self {
-
         let mut it = TstNeighborIterator {
-
-            todo_i: Vec::new(), last_i: None,
-            todo_j: Vec::new(), last_j: None,
+            todo_i: Vec::new(),
+            last_i: None,
+            todo_j: Vec::new(),
+            last_j: None,
         };
 
         if let Some(ref node) = &tst.root {
-
             let mut key_tail = key.chars();
             let key_len = key.chars().count();
             let label = key_tail.next();
-            let tail_len = if key_len == 0 { 0 } else {key_len-1 };
+            let tail_len = if key_len == 0 { 0 } else { key_len - 1 };
 
-            it.todo_i.push((node, GoLeft, label, key_tail.clone(), tail_len, range));
-            it.todo_j.push((node, GoRight, label, key_tail, tail_len, range));
+            it.todo_i
+                .push((node, GoLeft, label, key_tail.clone(), tail_len, range));
+            it.todo_j
+                .push((node, GoRight, label, key_tail, tail_len, range));
         }
 
         it
     }
 
-
     gen_it_path!(current_key, todo_i, GoMiddle, GoRight);
     gen_it_path!(current_key_back, todo_j, Visit, GoLeft);
 }
 
-
 impl<'a, 'b, T> Iterator for TstNeighborIterator<'a, 'b, T> {
-
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
-
         let mut found = None;
 
         while let Some((node, action, label, mut key_tail, tail_len, range)) = self.todo_i.pop() {
-
             match action {
-
                 GoLeft => {
-
-                    self.todo_i.push((node, Visit, label, key_tail.clone(), tail_len, range));
+                    self.todo_i
+                        .push((node, Visit, label, key_tail.clone(), tail_len, range));
 
                     if let Some(label) = label {
-
                         if range == 0 && label >= node.label {
-
                             continue;
                         }
                     }
 
                     if let Some(ref child) = node.left {
-
-                        self.todo_i.push((child, GoLeft, label, key_tail, tail_len, range));
+                        self.todo_i
+                            .push((child, GoLeft, label, key_tail, tail_len, range));
                     }
                 }
 
                 Visit => {
-
                     if node.value.is_some() {
-
                         if let Some(node_j) = self.last_j {
-
                             if ptr::eq(node, node_j) {
-
                                 self.todo_i.clear();
                                 self.todo_j.clear();
 
@@ -1896,24 +1824,26 @@ impl<'a, 'b, T> Iterator for TstNeighborIterator<'a, 'b, T> {
                         }
                     }
 
-                    self.todo_i.push((node, GoMiddle, label, key_tail, tail_len, range));
+                    self.todo_i
+                        .push((node, GoMiddle, label, key_tail, tail_len, range));
 
                     if let Some(ref value) = node.value {
-
                         let delta = match label {
-
                             None => 1,
 
-                            Some(label) => if label==node.label { 0 } else { 1 }
-
+                            Some(label) => {
+                                if label == node.label {
+                                    0
+                                } else {
+                                    1
+                                }
+                            }
                         };
 
                         if range >= delta {
-
                             let new_range = range - delta;
 
-                            if tail_len  <= new_range {
-
+                            if tail_len <= new_range {
                                 self.last_i = Some(node);
                                 found = Some(value);
 
@@ -1924,43 +1854,44 @@ impl<'a, 'b, T> Iterator for TstNeighborIterator<'a, 'b, T> {
                 }
 
                 GoMiddle => {
-
-                    self.todo_i.push((node, GoRight, label, key_tail.clone(), tail_len, range));
+                    self.todo_i
+                        .push((node, GoRight, label, key_tail.clone(), tail_len, range));
 
                     let delta = match label {
-
                         None => 1,
 
-                        Some(label) => if label==node.label { 0 } else { 1 }
+                        Some(label) => {
+                            if label == node.label {
+                                0
+                            } else {
+                                1
+                            }
+                        }
                     };
 
                     if range >= delta {
-
                         let new_range = range - delta;
 
                         let new_label = key_tail.next();
-                        let new_len = if tail_len > 0 { tail_len-1 } else { tail_len };
+                        let new_len = if tail_len > 0 { tail_len - 1 } else { tail_len };
 
                         if let Some(ref child) = node.middle {
-
-                            self.todo_i.push((child, GoLeft, new_label, key_tail, new_len, new_range));
+                            self.todo_i
+                                .push((child, GoLeft, new_label, key_tail, new_len, new_range));
                         }
                     }
                 }
 
                 GoRight => {
-
                     if let Some(label) = label {
-
                         if range == 0 && label <= node.label {
-
                             continue;
                         }
                     }
 
                     if let Some(ref child) = node.right {
-
-                        self.todo_i.push((child, GoLeft, label, key_tail, tail_len, range));
+                        self.todo_i
+                            .push((child, GoLeft, label, key_tail, tail_len, range));
                     }
                 }
             }
@@ -1970,43 +1901,32 @@ impl<'a, 'b, T> Iterator for TstNeighborIterator<'a, 'b, T> {
     }
 }
 
-
 impl<'a, 'b, T> DoubleEndedIterator for TstNeighborIterator<'a, 'b, T> {
-
     fn next_back(&mut self) -> Option<&'a T> {
-
         let mut found = None;
 
         while let Some((node, action, label, mut key_tail, tail_len, range)) = self.todo_j.pop() {
-
             match action {
-
                 GoRight => {
-
-                    self.todo_j.push((node, GoMiddle, label, key_tail.clone(), tail_len, range));
+                    self.todo_j
+                        .push((node, GoMiddle, label, key_tail.clone(), tail_len, range));
 
                     if let Some(label) = label {
-
                         if range == 0 && label <= node.label {
-
                             continue;
                         }
                     }
 
                     if let Some(ref child) = node.right {
-
-                        self.todo_j.push((child, GoRight, label, key_tail, tail_len, range));
+                        self.todo_j
+                            .push((child, GoRight, label, key_tail, tail_len, range));
                     }
                 }
 
                 Visit => {
-
                     if node.value.is_some() {
-
                         if let Some(node_i) = self.last_i {
-
                             if ptr::eq(node, node_i) {
-
                                 self.todo_i.clear();
                                 self.todo_j.clear();
 
@@ -2016,24 +1936,26 @@ impl<'a, 'b, T> DoubleEndedIterator for TstNeighborIterator<'a, 'b, T> {
                         }
                     }
 
-                    self.todo_j.push((node, GoLeft, label, key_tail, tail_len, range));
+                    self.todo_j
+                        .push((node, GoLeft, label, key_tail, tail_len, range));
 
                     if let Some(ref value) = node.value {
-
                         let delta = match label {
-
                             None => 1,
 
-                            Some(label) => if label==node.label { 0 } else { 1 }
-
+                            Some(label) => {
+                                if label == node.label {
+                                    0
+                                } else {
+                                    1
+                                }
+                            }
                         };
 
                         if range >= delta {
-
                             let new_range = range - delta;
 
-                            if tail_len  <= new_range {
-
+                            if tail_len <= new_range {
                                 self.last_j = Some(node);
                                 found = Some(value);
 
@@ -2044,44 +1966,44 @@ impl<'a, 'b, T> DoubleEndedIterator for TstNeighborIterator<'a, 'b, T> {
                 }
 
                 GoMiddle => {
-
-                    self.todo_j.push((node, Visit, label, key_tail.clone(), tail_len, range));
+                    self.todo_j
+                        .push((node, Visit, label, key_tail.clone(), tail_len, range));
 
                     let delta = match label {
-
                         None => 1,
 
-                        Some(label) => if label==node.label { 0 } else { 1 }
-
+                        Some(label) => {
+                            if label == node.label {
+                                0
+                            } else {
+                                1
+                            }
+                        }
                     };
 
                     if range >= delta {
-
                         let new_range = range - delta;
 
                         let new_label = key_tail.next();
-                        let new_len = if tail_len > 0 { tail_len-1 } else { tail_len };
+                        let new_len = if tail_len > 0 { tail_len - 1 } else { tail_len };
 
                         if let Some(ref child) = node.middle {
-
-                            self.todo_j.push((child, GoRight, new_label, key_tail, new_len, new_range));
+                            self.todo_j
+                                .push((child, GoRight, new_label, key_tail, new_len, new_range));
                         }
                     }
                 }
 
                 GoLeft => {
-
                     if let Some(label) = label {
-
                         if range == 0 && label >= node.label {
-
                             continue;
                         }
                     }
 
                     if let Some(ref child) = node.left {
-
-                        self.todo_j.push((child, GoRight, label, key_tail, tail_len, range));
+                        self.todo_j
+                            .push((child, GoRight, label, key_tail, tail_len, range));
                     }
                 }
             }
@@ -2091,45 +2013,39 @@ impl<'a, 'b, T> DoubleEndedIterator for TstNeighborIterator<'a, 'b, T> {
     }
 }
 
-
 /// A [double-ended]( http://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html) iterator which
 /// successively returns all values whose key _matches_ `pattern`. See [`iter_crossword`](
 /// struct.Tst.html#method.iter_crossword) method for a brief description with a short example.
 
 #[derive(Debug)]
 pub struct TstCrosswordIterator<'a, 'b, T: 'a> {
-
     todo_i: Vec<(&'a Node<T>, TstIteratorAction, char, Chars<'b>, usize)>,
     last_i: Option<&'a Node<T>>,
 
     todo_j: Vec<(&'a Node<T>, TstIteratorAction, char, Chars<'b>, usize)>,
     last_j: Option<&'a Node<T>>,
 
-    joker: char
+    joker: char,
 }
 
-
 impl<'a, 'b, T> TstCrosswordIterator<'a, 'b, T> {
-
     pub fn new(tst: &'a Tst<T>, key: &'b str, joker: char) -> Self {
-
         let mut it = TstCrosswordIterator {
-
-            todo_i: Vec::new(), last_i: None,
-            todo_j: Vec::new(), last_j: None,
+            todo_i: Vec::new(),
+            last_i: None,
+            todo_j: Vec::new(),
+            last_j: None,
             joker,
-
         };
 
         if let Some(ref node) = &tst.root {
-
             let mut key_tail = key.chars();
 
             if let Some(label) = key_tail.next() {
+                let tail_len = key.chars().count() - 1;
 
-                let tail_len = key.chars().count()-1;
-
-                it.todo_i.push((node, GoLeft, label, key_tail.clone(), tail_len));
+                it.todo_i
+                    .push((node, GoLeft, label, key_tail.clone(), tail_len));
                 it.todo_j.push((node, GoRight, label, key_tail, tail_len));
             }
         }
@@ -2137,45 +2053,33 @@ impl<'a, 'b, T> TstCrosswordIterator<'a, 'b, T> {
         it
     }
 
-
     gen_it_path!(current_key, todo_i, GoMiddle, GoRight);
     gen_it_path!(current_key_back, todo_j, Visit, GoLeft);
 }
 
-
 impl<'a, 'b, T> Iterator for TstCrosswordIterator<'a, 'b, T> {
-
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
-
         let mut found = None;
 
         while let Some((node, action, label, mut key_tail, tail_len)) = self.todo_i.pop() {
-
             match action {
-
                 GoLeft => {
-
-                    self.todo_i.push((node, Visit, label, key_tail.clone(), tail_len));
+                    self.todo_i
+                        .push((node, Visit, label, key_tail.clone(), tail_len));
 
                     if label == self.joker || label < node.label {
-
                         if let Some(ref child) = node.left {
-
                             self.todo_i.push((child, GoLeft, label, key_tail, tail_len));
                         }
                     }
                 }
 
                 Visit => {
-
                     if node.value.is_some() {
-
                         if let Some(node_j) = self.last_j {
-
                             if ptr::eq(node, node_j) {
-
                                 self.todo_i.clear();
                                 self.todo_j.clear();
 
@@ -2185,12 +2089,11 @@ impl<'a, 'b, T> Iterator for TstCrosswordIterator<'a, 'b, T> {
                         }
                     }
 
-                    self.todo_i.push((node, GoMiddle, label, key_tail, tail_len));
+                    self.todo_i
+                        .push((node, GoMiddle, label, key_tail, tail_len));
 
                     if let Some(ref value) = node.value {
-
                         if tail_len == 0 && (label == self.joker || label == node.label) {
-
                             self.last_i = Some(node);
                             found = Some(value);
 
@@ -2200,27 +2103,27 @@ impl<'a, 'b, T> Iterator for TstCrosswordIterator<'a, 'b, T> {
                 }
 
                 GoMiddle => {
-
-                    self.todo_i.push((node, GoRight, label, key_tail.clone(), tail_len));
+                    self.todo_i
+                        .push((node, GoRight, label, key_tail.clone(), tail_len));
 
                     if label == self.joker || label == node.label {
-
                         if let Some(ref child) = node.middle {
-
                             if let Some(new_label) = key_tail.next() {
-
-                                self.todo_i.push((child, GoLeft, new_label, key_tail, tail_len-1));
+                                self.todo_i.push((
+                                    child,
+                                    GoLeft,
+                                    new_label,
+                                    key_tail,
+                                    tail_len - 1,
+                                ));
                             }
                         }
                     }
                 }
 
                 GoRight => {
-
                     if label == self.joker || label > node.label {
-
                         if let Some(ref child) = node.right {
-
                             self.todo_i.push((child, GoLeft, label, key_tail, tail_len));
                         }
                     }
@@ -2232,38 +2135,28 @@ impl<'a, 'b, T> Iterator for TstCrosswordIterator<'a, 'b, T> {
     }
 }
 
-
 impl<'a, 'b, T> DoubleEndedIterator for TstCrosswordIterator<'a, 'b, T> {
-
     fn next_back(&mut self) -> Option<&'a T> {
-
         let mut found = None;
 
         while let Some((node, action, label, mut key_tail, tail_len)) = self.todo_j.pop() {
-
             match action {
-
                 GoRight => {
-
-                    self.todo_j.push((node, GoMiddle, label, key_tail.clone(), tail_len));
+                    self.todo_j
+                        .push((node, GoMiddle, label, key_tail.clone(), tail_len));
 
                     if label == self.joker || label > node.label {
-
                         if let Some(ref child) = node.right {
-
-                            self.todo_j.push((child, GoRight, label, key_tail, tail_len));
+                            self.todo_j
+                                .push((child, GoRight, label, key_tail, tail_len));
                         }
                     }
                 }
 
                 Visit => {
-
                     if node.value.is_some() {
-
                         if let Some(node_i) = self.last_i {
-
                             if ptr::eq(node, node_i) {
-
                                 self.todo_i.clear();
                                 self.todo_j.clear();
 
@@ -2276,9 +2169,7 @@ impl<'a, 'b, T> DoubleEndedIterator for TstCrosswordIterator<'a, 'b, T> {
                     self.todo_j.push((node, GoLeft, label, key_tail, tail_len));
 
                     if let Some(ref value) = node.value {
-
                         if tail_len == 0 && (label == self.joker || label == node.label) {
-
                             self.last_j = Some(node);
                             found = Some(value);
 
@@ -2288,28 +2179,29 @@ impl<'a, 'b, T> DoubleEndedIterator for TstCrosswordIterator<'a, 'b, T> {
                 }
 
                 GoMiddle => {
-
-                    self.todo_j.push((node, Visit, label, key_tail.clone(), tail_len));
+                    self.todo_j
+                        .push((node, Visit, label, key_tail.clone(), tail_len));
 
                     if label == self.joker || label == node.label {
-
                         if let Some(ref child) = node.middle {
-
                             if let Some(new_label) = key_tail.next() {
-
-                                self.todo_j.push((child, GoRight, new_label, key_tail, tail_len-1));
+                                self.todo_j.push((
+                                    child,
+                                    GoRight,
+                                    new_label,
+                                    key_tail,
+                                    tail_len - 1,
+                                ));
                             }
                         }
                     }
                 }
 
                 GoLeft => {
-
                     if label == self.joker || label < node.label {
-
                         if let Some(ref child) = node.left {
-
-                            self.todo_j.push((child, GoRight, label, key_tail, tail_len));
+                            self.todo_j
+                                .push((child, GoRight, label, key_tail, tail_len));
                         }
                     }
                 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -67,6 +67,38 @@ fn tst_get_value_back_on_empty_key() {
     assert_eq!(map.len(), 0);
 }
 
+#[test]
+fn tst_remove_leftmost() {
+    let mut map = Tst::new();
+    /*
+       b              c
+      / \            /|\
+     a   e     ->   a ć e
+        /|\            /|\
+       c ę f          d ę f
+       |\
+       ć d
+    */
+    map.insert("b", "B");
+    map.insert("a", "A");
+    map.insert("eę", "EĘ");
+    map.insert("c", "C");
+    map.insert("cć", "CĆ");
+    map.insert("f", "F");
+    map.insert("d", "D");
+    assert_eq!(map.len(), 7);
+    assert_eq!(map.remove("b"), Some("B"));
+    assert_eq!(map.len(), 6);
+    assert_eq!(map.get("a"), Some(&"A"));
+    assert_eq!(map.get("b"), None);
+    assert_eq!(map.get("c"), Some(&"C"));
+    assert_eq!(map.get("cć"), Some(&"CĆ"));
+    assert_eq!(map.get("d"), Some(&"D"));
+    assert_eq!(map.get("e"), None);
+    assert_eq!(map.get("eę"), Some(&"EĘ"));
+    assert_eq!(map.get("f"), Some(&"F"));
+}
+
 const RANDOM_VEC_123: [&str; 16] = [
     "aba", "ab", "bc", "ac", "abc", "a", "b", "aca", "caa", "cbc", "bac", "c", "cca", "aab", "abb",
     "aa",

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -159,6 +159,16 @@ fn get_sample_map_abc_abc_with_unicode() -> Tst<std::string::String> {
 }
 
 #[test]
+fn tst_get_nth() {
+    let map = get_sample_map_abc_abc();
+    for (n, expected) in SORTED_VEC_123.iter().enumerate() {
+        let (key, value) = map.get_nth(n).unwrap();
+        assert_eq!(&key, expected);
+        assert_eq!(value == expected, true);
+    }
+}
+
+#[test]
 fn tst_insert_and_get_more_key_value() {
     let map = get_sample_map_abc_count();
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1341,11 +1341,11 @@ fn tst_stats_on_insert_and_remove() {
     assert_eq!(s1.count.values, 0);
     assert_eq!(s1.count.values, empty_map.len());
 
-    //node struct size should be around 32 bytes on x64
+    //node struct size should be around 40 bytes on x64
     assert_eq!(s1.bytes.node >= 16, true);
     assert_eq!(s1.bytes.node <= 64, true);
 
-    //main tree struct size should be around 16 bytes on x64
+    //main tree struct size should be around 8 bytes on x64
     assert_eq!(s1.bytes.total >= 8, true);
     assert_eq!(s1.bytes.total <= 32, true);
 
@@ -1360,13 +1360,13 @@ fn tst_stats_on_insert_and_remove() {
     assert_eq!(s2.count.values, 16);
     assert_eq!(s2.count.values, map.len());
 
-    //node struct size should be around 48 bytes on x64
+    //node struct size should be around 56 bytes on x64
     assert_eq!(s2.bytes.node >= 24, true);
     assert_eq!(s2.bytes.node <= 96, true);
 
-    //total size should be around 976 bytes on x64
+    //total size should be around 1128 bytes on x64
     assert_eq!(s2.bytes.total >= 488, true);
-    assert_eq!(s2.bytes.total <= 16 + 20 * 48, true);
+    assert_eq!(s2.bytes.total <= 16 + 20 * 56, true);
 
     assert_eq!(s1.bytes.node < s2.bytes.node, true);
     assert_eq!(s1.bytes.total < s2.bytes.total, true);
@@ -1698,13 +1698,11 @@ fn tst_create_with_macro() {
     assert_eq!(stat.count.values, 16);
     assert_eq!(stat.count.values, map.len());
 
-    //node struct size should be around 48 bytes on x64
-    assert_eq!(stat.bytes.node >= 24, true);
-    assert_eq!(stat.bytes.node <= 96, true);
+    //node struct size should be around 56 bytes on x64
+    assert_eq!(stat.bytes.node, 56);
 
-    //total size should be around 976 bytes on x64
-    assert_eq!(stat.bytes.total >= 488, true);
-    assert_eq!(stat.bytes.total <= 16 + 20 * 48, true);
+    //total size should be around 1128 bytes on x64
+    assert_eq!(stat.bytes.total, 8 + 20 * 56);
 
     use ternary_tree::DistStat;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -68,17 +68,8 @@ fn tst_get_value_back_on_empty_key() {
 }
 
 #[test]
-fn tst_remove_leftmost() {
+fn tst_remove_root() {
     let mut map = Tst::new();
-    /*
-       b              c
-      / \            /|\
-     a   e     ->   a ć e
-        /|\            /|\
-       c ę f          d ę f
-       |\
-       ć d
-    */
     map.insert("b", "B");
     map.insert("a", "A");
     map.insert("eę", "EĘ");
@@ -165,6 +156,17 @@ fn tst_get_nth() {
         let (key, value) = map.get_nth(n).unwrap();
         assert_eq!(&key, expected);
         assert_eq!(value == expected, true);
+    }
+}
+
+#[test]
+fn tst_random() {
+    let mut map = get_sample_map_abc_count();
+    for i in 0..1000 {
+        map.insert(RANDOM_VEC_123[i % RANDOM_VEC_123.len()], i);
+        map.verify();
+        map.remove(RANDOM_VEC_123_BIS[(i * i) % RANDOM_VEC_123_BIS.len()]);
+        map.verify();
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,18 +1,14 @@
 extern crate ternary_tree;
 use ternary_tree::Tst;
 
-
 #[test]
 fn tst_create_empty_map() {
-
     let map: Tst<String> = Tst::new();
     assert_eq!(map.len(), 0);
 }
 
-
 #[test]
 fn tst_insert_some_key_value() {
-
     let mut map = Tst::new();
     assert_eq!(map.len(), 0);
 
@@ -21,10 +17,8 @@ fn tst_insert_some_key_value() {
     assert_eq!(map.len(), 1);
 }
 
-
 #[test]
 fn tst_get_some_value_by_key() {
-
     let mut map = Tst::new();
     assert_eq!(map.len(), 0);
 
@@ -41,10 +35,8 @@ fn tst_get_some_value_by_key() {
     assert_eq!(v2, v1);
 }
 
-
 #[test]
 fn tst_replace_some_value() {
-
     let mut map = Tst::new();
     assert_eq!(map.len(), 0);
 
@@ -65,10 +57,8 @@ fn tst_replace_some_value() {
     assert_eq!(v2, Some(&"v2"));
 }
 
-
 #[test]
 fn tst_get_value_back_on_empty_key() {
-
     let mut map = Tst::new();
     assert_eq!(map.len(), 0);
 
@@ -77,22 +67,27 @@ fn tst_get_value_back_on_empty_key() {
     assert_eq!(map.len(), 0);
 }
 
+const RANDOM_VEC_123: [&str; 16] = [
+    "aba", "ab", "bc", "ac", "abc", "a", "b", "aca", "caa", "cbc", "bac", "c", "cca", "aab", "abb",
+    "aa",
+];
 
-const RANDOM_VEC_123 : [&str; 16] = ["aba", "ab", "bc", "ac", "abc", "a", "b", "aca", "caa", "cbc", "bac", "c", "cca", "aab", "abb", "aa"];
+const RANDOM_VEC_123_BIS: [&str; 16] = [
+    "cca", "aa", "bac", "aba", "b", "bc", "c", "ac", "aab", "ab", "abc", "abb", "a", "caa", "aca",
+    "cbc",
+];
 
-const RANDOM_VEC_123_BIS : [&str; 16] = [ "cca", "aa", "bac", "aba", "b", "bc", "c", "ac", "aab", "ab", "abc", "abb", "a", "caa", "aca", "cbc" ];
-
-const SORTED_VEC_123 : [&str; 16] = ["a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "b", "bac", "bc", "c", "caa", "cbc", "cca"];
-
+const SORTED_VEC_123: [&str; 16] = [
+    "a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "b", "bac", "bc", "c", "caa", "cbc",
+    "cca",
+];
 
 fn get_sample_map_abc_count() -> Tst<usize> {
-
     let mut map = Tst::new();
     let mut count = 0;
 
     for k in RANDOM_VEC_123.iter() {
-
-        count+=1;
+        count += 1;
         let old_value = map.insert(k, count);
         assert_eq!(old_value, None);
         assert_eq!(map.len(), count);
@@ -101,15 +96,12 @@ fn get_sample_map_abc_count() -> Tst<usize> {
     map
 }
 
-
 fn get_sample_map_abc_abc() -> Tst<&'static str> {
-
     let mut map = Tst::new();
     let mut count = 0;
 
     for k in RANDOM_VEC_123.iter() {
-
-        count+=1;
+        count += 1;
         let old_value = map.insert(k, *k);
         assert_eq!(old_value, None);
         assert_eq!(map.len(), count);
@@ -118,17 +110,14 @@ fn get_sample_map_abc_abc() -> Tst<&'static str> {
     map
 }
 
-
 fn get_sample_map_abc_abc_with_unicode() -> Tst<std::string::String> {
-
     let mut map = Tst::new();
     let mut count = 0;
 
     for k in RANDOM_VEC_123.iter() {
-
-        count+=1;
-        let key = "🗝".to_owned()+k;
-        let val = "📦".to_owned()+k;
+        count += 1;
+        let key = "🗝".to_owned() + k;
+        let val = "📦".to_owned() + k;
         let old_value = map.insert(&key, val);
         assert_eq!(old_value, None);
         assert_eq!(map.len(), count);
@@ -137,23 +126,18 @@ fn get_sample_map_abc_abc_with_unicode() -> Tst<std::string::String> {
     map
 }
 
-
 #[test]
 fn tst_insert_and_get_more_key_value() {
-
     let map = get_sample_map_abc_count();
 
     for k in SORTED_VEC_123.iter() {
-
         let value = map.get(k);
         assert_eq!(*value.unwrap() > 0, true);
     }
 }
 
-
 #[test]
 fn tst_iterate_over_empty_tree() {
-
     let empty_map: Tst<bool> = Tst::new();
     assert_eq!(empty_map.len(), 0);
 
@@ -166,10 +150,8 @@ fn tst_iterate_over_empty_tree() {
     assert_eq!(it.next_back(), None);
 }
 
-
 #[test]
 fn tst_iterate_over_values() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -185,7 +167,6 @@ fn tst_iterate_over_values() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -195,27 +176,22 @@ fn tst_iterate_over_values() {
     assert_eq!(it.next(), None);
 }
 
-
 #[test]
 fn tst_iterate_over_values_with_for_loop() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
     let mut v = Vec::new();
 
     for value in &map {
-
         v.push(*value);
     }
 
     assert_eq!(v, SORTED_VEC_123);
 }
 
-
 #[test]
 fn tst_iterate_over_values_with_peek_and_co() {
-
     let map = get_sample_map_abc_count();
     assert_eq!(map.len(), 16);
 
@@ -234,13 +210,11 @@ fn tst_iterate_over_values_with_peek_and_co() {
     let sum = map.iter().fold(0, |acc, v| acc + *v);
     let n = map.len();
 
-    assert_eq!(sum, n*(n+1)/2);
+    assert_eq!(sum, n * (n + 1) / 2);
 }
-
 
 #[test]
 fn tst_iterate_over_values_backward() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -256,7 +230,6 @@ fn tst_iterate_over_values_backward() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -268,10 +241,8 @@ fn tst_iterate_over_values_backward() {
     assert_eq!(it.next_back(), None);
 }
 
-
 #[test]
 fn tst_iterate_over_values_backward_with_rev() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -287,7 +258,6 @@ fn tst_iterate_over_values_backward_with_rev() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -299,10 +269,8 @@ fn tst_iterate_over_values_backward_with_rev() {
     assert_eq!(it.next(), None);
 }
 
-
 #[test]
 fn tst_iterate_over_values_from_both_end() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -310,7 +278,6 @@ fn tst_iterate_over_values_from_both_end() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -325,7 +292,6 @@ fn tst_iterate_over_values_from_both_end() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -344,13 +310,9 @@ fn tst_iterate_over_values_from_both_end() {
     let mut vj = Vec::new();
 
     for i in 0..map.len() {
-
-        if i%2 == 0 {
-
+        if i % 2 == 0 {
             vi.push(*it.next().unwrap());
-
         } else {
-
             vj.push(*it.next_back().unwrap());
         }
     }
@@ -364,10 +326,8 @@ fn tst_iterate_over_values_from_both_end() {
     assert_eq!(vj, ["aca", "b", "bac", "bc", "c", "caa", "cbc", "cca"]);
 }
 
-
 #[test]
 fn tst_visit_values() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -378,10 +338,8 @@ fn tst_visit_values() {
     assert_eq!(v, SORTED_VEC_123);
 }
 
-
 #[test]
 fn tst_visit_complete_values() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -391,18 +349,16 @@ fn tst_visit_complete_values() {
     map.visit_complete_values("bc", |s| assert_eq!(s, &"woups"));
 
     let mut v = Vec::new();
-    map.visit_complete_values("ab", |s| {v.push(s.clone())});
+    map.visit_complete_values("ab", |s| v.push(s.clone()));
     assert_eq!(v, ["aba", "abb", "abc"]);
 
     v.clear();
-    map.visit_complete_values("", |s| {v.push(s.clone())});
+    map.visit_complete_values("", |s| v.push(s.clone()));
     assert_eq!(v, SORTED_VEC_123);
 }
 
-
 #[test]
 fn tst_visit_neighbor_values() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -412,46 +368,47 @@ fn tst_visit_neighbor_values() {
     map.visit_neighbor_values("abc", 0, |s| assert_eq!(s, &"abc"));
 
     let mut v = Vec::new();
-    map.visit_neighbor_values("abc", 1, |s| {v.push(s.clone())});
+    map.visit_neighbor_values("abc", 1, |s| v.push(s.clone()));
     assert_eq!(v, ["ab", "aba", "abb", "abc", "cbc"]);
 
     v.clear();
-    map.visit_neighbor_values("abc", 2, |s| {v.push(s.clone())});
-    assert_eq!(v, ["a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "bac", "cbc"]);
+    map.visit_neighbor_values("abc", 2, |s| v.push(s.clone()));
+    assert_eq!(
+        v,
+        ["a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "bac", "cbc"]
+    );
 
     v.clear();
-    map.visit_neighbor_values("abc", 3, |s| {v.push(s.clone())});
+    map.visit_neighbor_values("abc", 3, |s| v.push(s.clone()));
     assert_eq!(v, SORTED_VEC_123);
 
     v.clear();
-    map.visit_neighbor_values("xxxx", 4, |s| {v.push(s.clone())});
+    map.visit_neighbor_values("xxxx", 4, |s| v.push(s.clone()));
     assert_eq!(v, SORTED_VEC_123);
 
     v.clear();
-    map.visit_neighbor_values("", 0, |s| {v.push(s.clone())});
+    map.visit_neighbor_values("", 0, |s| v.push(s.clone()));
     assert_eq!(v.is_empty(), true);
 
     v.clear();
-    map.visit_neighbor_values("", 1, |s| {v.push(s.clone())});
+    map.visit_neighbor_values("", 1, |s| v.push(s.clone()));
     assert_eq!(v, ["a", "b", "c"]);
 
     v.clear();
-    map.visit_neighbor_values("", 2, |s| {v.push(s.clone())});
+    map.visit_neighbor_values("", 2, |s| v.push(s.clone()));
     assert_eq!(v, ["a", "aa", "ab", "ac", "b", "bc", "c"]);
 
     v.clear();
-    map.visit_neighbor_values("", 3, |s| {v.push(s.clone())});
+    map.visit_neighbor_values("", 3, |s| v.push(s.clone()));
     assert_eq!(v, SORTED_VEC_123);
 
     v.clear();
-    map.visit_neighbor_values("", 4, |s| {v.push(s.clone())});
+    map.visit_neighbor_values("", 4, |s| v.push(s.clone()));
     assert_eq!(v, SORTED_VEC_123);
 }
 
-
 #[test]
 fn tst_visit_crossword_values() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -478,7 +435,10 @@ fn tst_visit_crossword_values() {
 
     v.clear();
     map.visit_crossword_values("???", '?', |s| v.push(s.clone()));
-    assert_eq!(v, ["aab", "aba", "abb", "abc", "aca", "bac", "caa", "cbc", "cca"]);
+    assert_eq!(
+        v,
+        ["aab", "aba", "abb", "abc", "aca", "bac", "caa", "cbc", "cca"]
+    );
 
     v.clear();
     map.visit_crossword_values("????", '?', |s| v.push(s.clone()));
@@ -489,10 +449,8 @@ fn tst_visit_crossword_values() {
     assert_eq!(v, ["aba", "aca"]);
 }
 
-
 #[test]
 fn tst_iterate_with_complete() {
-
     let empty_map: Tst<bool> = Tst::new();
     assert_eq!(empty_map.len(), 0);
 
@@ -523,7 +481,6 @@ fn tst_iterate_with_complete() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -535,7 +492,6 @@ fn tst_iterate_with_complete() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -555,10 +511,8 @@ fn tst_iterate_with_complete() {
     assert_eq!(it.next(), None);
 }
 
-
 #[test]
 fn tst_iterate_with_neighbor() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -566,7 +520,6 @@ fn tst_iterate_with_neighbor() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -578,7 +531,6 @@ fn tst_iterate_with_neighbor() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -590,7 +542,6 @@ fn tst_iterate_with_neighbor() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -602,7 +553,6 @@ fn tst_iterate_with_neighbor() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -614,11 +564,13 @@ fn tst_iterate_with_neighbor() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
-    assert_eq!(v, ["a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "bac", "cbc"]);
+    assert_eq!(
+        v,
+        ["a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "bac", "cbc"]
+    );
 
     ////////////////////////////////////////////////////
 
@@ -626,7 +578,6 @@ fn tst_iterate_with_neighbor() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -638,7 +589,6 @@ fn tst_iterate_with_neighbor() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -650,7 +600,6 @@ fn tst_iterate_with_neighbor() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -662,7 +611,6 @@ fn tst_iterate_with_neighbor() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -674,7 +622,6 @@ fn tst_iterate_with_neighbor() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -686,7 +633,6 @@ fn tst_iterate_with_neighbor() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -698,30 +644,27 @@ fn tst_iterate_with_neighbor() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
     assert_eq!(v, SORTED_VEC_123);
 }
 
-
 #[test]
 fn tst_fix_unicode_chars_in_key_bug() {
-
     let map = get_sample_map_abc_abc_with_unicode();
     assert_eq!(map.len(), 16);
 
     let mut v = Vec::new();
-    map.visit_neighbor_values("🗝abc", 0, |s| {v.push(s.clone())});
+    map.visit_neighbor_values("🗝abc", 0, |s| v.push(s.clone()));
     assert_eq!(v, ["📦abc"]);
 
     v.clear();
-    map.visit_neighbor_values("🗝abc", 1, |s| {v.push(s.clone())});
+    map.visit_neighbor_values("🗝abc", 1, |s| v.push(s.clone()));
     assert_eq!(v, ["📦ab", "📦aba", "📦abb", "📦abc", "📦cbc"]);
 
     v.clear();
-    map.visit_neighbor_values("xabc", 2, |s| {v.push(s.clone())});
+    map.visit_neighbor_values("xabc", 2, |s| v.push(s.clone()));
     assert_eq!(v, ["📦ab", "📦aba", "📦abb", "📦abc", "📦cbc"]);
 
     ////////////////////////////////////////////////////
@@ -730,7 +673,6 @@ fn tst_fix_unicode_chars_in_key_bug() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next() {
-
         v.push(value);
     }
 
@@ -742,7 +684,6 @@ fn tst_fix_unicode_chars_in_key_bug() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(value);
     }
 
@@ -754,7 +695,6 @@ fn tst_fix_unicode_chars_in_key_bug() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(value);
     }
 
@@ -766,7 +706,6 @@ fn tst_fix_unicode_chars_in_key_bug() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(value);
     }
 
@@ -778,17 +717,14 @@ fn tst_fix_unicode_chars_in_key_bug() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(value);
     }
 
     assert_eq!(v, ["📦aab", "📦bac", "📦caa"]);
 }
 
-
 #[test]
 fn tst_iterate_with_neighbor_backward() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -796,7 +732,6 @@ fn tst_iterate_with_neighbor_backward() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -810,7 +745,6 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -822,7 +756,6 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -834,7 +767,6 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -846,7 +778,6 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -860,13 +791,15 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
     v.reverse();
 
-    assert_eq!(v, ["a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "bac", "cbc"]);
+    assert_eq!(
+        v,
+        ["a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "bac", "cbc"]
+    );
 
     ////////////////////////////////////////////////////
 
@@ -874,7 +807,6 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -888,7 +820,6 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -902,7 +833,6 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -914,7 +844,6 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -928,7 +857,6 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -942,7 +870,6 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -956,7 +883,6 @@ fn tst_iterate_with_neighbor_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -965,10 +891,8 @@ fn tst_iterate_with_neighbor_backward() {
     assert_eq!(v, SORTED_VEC_123);
 }
 
-
 #[test]
 fn tst_iterate_with_neighbor_from_both_end() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -976,11 +900,13 @@ fn tst_iterate_with_neighbor_from_both_end() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
-    assert_eq!(v, ["a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "bac", "cbc"]);
+    assert_eq!(
+        v,
+        ["a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "bac", "cbc"]
+    );
 
     assert_eq!(it.next(), None);
     assert_eq!(it.next_back(), None);
@@ -991,13 +917,15 @@ fn tst_iterate_with_neighbor_from_both_end() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
     v.reverse();
 
-    assert_eq!(v, ["a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "bac", "cbc"]);
+    assert_eq!(
+        v,
+        ["a", "aa", "aab", "ab", "aba", "abb", "abc", "ac", "aca", "bac", "cbc"]
+    );
 
     assert_eq!(it.next_back(), None);
     assert_eq!(it.next(), None);
@@ -1014,13 +942,9 @@ fn tst_iterate_with_neighbor_from_both_end() {
     let mut vj = Vec::new();
 
     for i in 0..count {
-
-        if i%2 == 0 {
-
+        if i % 2 == 0 {
             vi.push(*it.next().unwrap());
-
         } else {
-
             vj.push(*it.next_back().unwrap());
         }
     }
@@ -1034,10 +958,8 @@ fn tst_iterate_with_neighbor_from_both_end() {
     assert_eq!(vj, ["abc", "ac", "aca", "bac", "cbc"]);
 }
 
-
 #[test]
 fn tst_iterate_with_crossword() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -1045,7 +967,6 @@ fn tst_iterate_with_crossword() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -1057,7 +978,6 @@ fn tst_iterate_with_crossword() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -1069,7 +989,6 @@ fn tst_iterate_with_crossword() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -1081,7 +1000,6 @@ fn tst_iterate_with_crossword() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -1093,7 +1011,6 @@ fn tst_iterate_with_crossword() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -1105,11 +1022,13 @@ fn tst_iterate_with_crossword() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
-    assert_eq!(v, ["aab", "aba", "abb", "abc", "aca", "bac", "caa", "cbc", "cca"]);
+    assert_eq!(
+        v,
+        ["aab", "aba", "abb", "abc", "aca", "bac", "caa", "cbc", "cca"]
+    );
 
     ////////////////////////////////////////////////////
 
@@ -1117,17 +1036,14 @@ fn tst_iterate_with_crossword() {
     v.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
     assert_eq!(v.is_empty(), true);
 }
-
 
 #[test]
 fn tst_iterate_with_crossword_backward() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -1135,7 +1051,6 @@ fn tst_iterate_with_crossword_backward() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -1149,7 +1064,6 @@ fn tst_iterate_with_crossword_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -1163,7 +1077,6 @@ fn tst_iterate_with_crossword_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -1177,7 +1090,6 @@ fn tst_iterate_with_crossword_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -1191,7 +1103,6 @@ fn tst_iterate_with_crossword_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -1205,13 +1116,15 @@ fn tst_iterate_with_crossword_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
     v.reverse();
 
-    assert_eq!(v, ["aab", "aba", "abb", "abc", "aca", "bac", "caa", "cbc", "cca"]);
+    assert_eq!(
+        v,
+        ["aab", "aba", "abb", "abc", "aca", "bac", "caa", "cbc", "cca"]
+    );
 
     ////////////////////////////////////////////////////
 
@@ -1219,7 +1132,6 @@ fn tst_iterate_with_crossword_backward() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -1228,10 +1140,8 @@ fn tst_iterate_with_crossword_backward() {
     assert_eq!(v.is_empty(), true);
 }
 
-
 #[test]
 fn tst_iterate_with_crossword_from_both_end() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -1239,7 +1149,6 @@ fn tst_iterate_with_crossword_from_both_end() {
     let mut v = Vec::new();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
     }
 
@@ -1254,7 +1163,6 @@ fn tst_iterate_with_crossword_from_both_end() {
     v.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
     }
 
@@ -1277,13 +1185,9 @@ fn tst_iterate_with_crossword_from_both_end() {
     let mut vj = Vec::new();
 
     for i in 0..count {
-
-        if i%2 == 0 {
-
+        if i % 2 == 0 {
             vi.push(*it.next().unwrap());
-
         } else {
-
             vj.push(*it.next_back().unwrap());
         }
     }
@@ -1297,10 +1201,8 @@ fn tst_iterate_with_crossword_from_both_end() {
     assert_eq!(vj, ["caa"]);
 }
 
-
 #[test]
 fn tst_insert_and_remove_some_key_value() {
-
     let mut empty_map: Tst<bool> = Tst::new();
     assert_eq!(empty_map.len(), 0);
 
@@ -1339,14 +1241,11 @@ fn tst_insert_and_remove_some_key_value() {
     assert_eq!(map.len(), 0);
 }
 
-
 #[test]
 fn tst_insert_and_remove_more_key_value() {
-
     let mut map = get_sample_map_abc_abc();
 
     for k in RANDOM_VEC_123_BIS.iter() {
-
         let len = map.len();
 
         {
@@ -1357,17 +1256,17 @@ fn tst_insert_and_remove_more_key_value() {
 
         let value = map.remove(k);
         assert_eq!(value, Some(*k));
-        assert_eq!(map.len(), len-1);
+        assert_eq!(map.len(), len - 1);
 
         {
             let value = map.get(k);
             assert_eq!(value, None);
-            assert_eq!(map.len(), len-1);
+            assert_eq!(map.len(), len - 1);
         }
 
         let value = map.remove(k);
         assert_eq!(value, None);
-        assert_eq!(map.len(), len-1);
+        assert_eq!(map.len(), len - 1);
     }
 
     assert_eq!(map.len(), 0);
@@ -1397,10 +1296,8 @@ fn tst_insert_and_remove_more_key_value() {
     assert_eq!(map.len(), 0);
 }
 
-
 #[test]
 fn tst_stats_on_insert_and_remove() {
-
     let empty_map: Tst<bool> = Tst::new();
 
     let s1 = empty_map.stat();
@@ -1437,21 +1334,77 @@ fn tst_stats_on_insert_and_remove() {
 
     //total size should be around 976 bytes on x64
     assert_eq!(s2.bytes.total >= 488, true);
-    assert_eq!(s2.bytes.total <= 16+20*48, true);
+    assert_eq!(s2.bytes.total <= 16 + 20 * 48, true);
 
     assert_eq!(s1.bytes.node < s2.bytes.node, true);
     assert_eq!(s1.bytes.total < s2.bytes.total, true);
 
     use ternary_tree::DistStat;
 
-    assert_eq!(s2.dist[0], DistStat { matches: 0, sides: 3, depth: 0 });
-    assert_eq!(s2.dist[1], DistStat { matches: 3, sides: 7, depth: 1 });
-    assert_eq!(s2.dist[2], DistStat { matches: 4, sides: 4, depth: 2 });
-    assert_eq!(s2.dist[3], DistStat { matches: 9, sides: 1, depth: 5 });
-    assert_eq!(s2.dist[4], DistStat { matches: 0, sides: 1, depth: 3 });
-    assert_eq!(s2.dist[5], DistStat { matches: 0, sides: 0, depth: 3 });
-    assert_eq!(s2.dist[6], DistStat { matches: 0, sides: 0, depth: 1 });
-    assert_eq!(s2.dist[7], DistStat { matches: 0, sides: 0, depth: 1 });
+    assert_eq!(
+        s2.dist[0],
+        DistStat {
+            matches: 0,
+            sides: 3,
+            depth: 0
+        }
+    );
+    assert_eq!(
+        s2.dist[1],
+        DistStat {
+            matches: 3,
+            sides: 7,
+            depth: 1
+        }
+    );
+    assert_eq!(
+        s2.dist[2],
+        DistStat {
+            matches: 4,
+            sides: 4,
+            depth: 2
+        }
+    );
+    assert_eq!(
+        s2.dist[3],
+        DistStat {
+            matches: 9,
+            sides: 1,
+            depth: 5
+        }
+    );
+    assert_eq!(
+        s2.dist[4],
+        DistStat {
+            matches: 0,
+            sides: 1,
+            depth: 3
+        }
+    );
+    assert_eq!(
+        s2.dist[5],
+        DistStat {
+            matches: 0,
+            sides: 0,
+            depth: 3
+        }
+    );
+    assert_eq!(
+        s2.dist[6],
+        DistStat {
+            matches: 0,
+            sides: 0,
+            depth: 1
+        }
+    );
+    assert_eq!(
+        s2.dist[7],
+        DistStat {
+            matches: 0,
+            sides: 0,
+            depth: 1
+        }
+    );
     assert_eq!(s2.dist.len(), 8);
 
     ////////////////////////////////////////////////////
@@ -1463,7 +1416,6 @@ fn tst_stats_on_insert_and_remove() {
     assert_eq!(s.count.values, 0);
 
     for k in RANDOM_VEC_123.iter() {
-
         let s1 = map.stat();
         map.insert(k, *k);
         let s2 = map.stat();
@@ -1474,7 +1426,6 @@ fn tst_stats_on_insert_and_remove() {
     }
 
     for k in RANDOM_VEC_123_BIS.iter() {
-
         let s1 = map.stat();
         map.remove(k);
         let s2 = map.stat();
@@ -1489,10 +1440,8 @@ fn tst_stats_on_insert_and_remove() {
     assert_eq!(s.count.values, 0);
 }
 
-
 #[test]
 fn tst_clear_some_map() {
-
     let mut empty_map: Tst<bool> = Tst::new();
 
     empty_map.clear();
@@ -1522,10 +1471,8 @@ fn tst_clear_some_map() {
     assert_eq!(s.count.values, map.len());
 }
 
-
 #[test]
 fn tst_iterate_and_read_current_key() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -1534,7 +1481,6 @@ fn tst_iterate_and_read_current_key() {
     let mut w = Vec::new();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
         w.push(it.current_key());
     }
@@ -1543,10 +1489,8 @@ fn tst_iterate_and_read_current_key() {
     assert_eq!(w, SORTED_VEC_123);
 }
 
-
 #[test]
 fn tst_iterate_and_read_current_key_back() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -1555,7 +1499,6 @@ fn tst_iterate_and_read_current_key_back() {
     let mut w = Vec::new();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
         w.push(it.current_key_back());
     }
@@ -1567,10 +1510,8 @@ fn tst_iterate_and_read_current_key_back() {
     assert_eq!(w, SORTED_VEC_123);
 }
 
-
 #[test]
 fn tst_current_key_iterators() {
-
     let map = get_sample_map_abc_abc();
     assert_eq!(map.len(), 16);
 
@@ -1579,7 +1520,6 @@ fn tst_current_key_iterators() {
     let mut w = Vec::new();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
         w.push(it.current_key());
     }
@@ -1593,7 +1533,6 @@ fn tst_current_key_iterators() {
     w.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
         w.push(it.current_key_back());
     }
@@ -1607,7 +1546,6 @@ fn tst_current_key_iterators() {
     w.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
         w.push(it.current_key());
     }
@@ -1621,7 +1559,6 @@ fn tst_current_key_iterators() {
     w.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
         w.push(it.current_key_back());
     }
@@ -1635,7 +1572,6 @@ fn tst_current_key_iterators() {
     w.clear();
 
     while let Some(value) = it.next() {
-
         v.push(*value);
         w.push(it.current_key());
     }
@@ -1649,7 +1585,6 @@ fn tst_current_key_iterators() {
     w.clear();
 
     while let Some(value) = it.next_back() {
-
         v.push(*value);
         w.push(it.current_key_back());
     }
@@ -1657,19 +1592,15 @@ fn tst_current_key_iterators() {
     assert_eq!(v, w);
 }
 
-
 #[test]
 fn tst_update_some_values() {
-
     let mut map = get_sample_map_abc_count();
     assert_eq!(map.len(), 16);
 
     for k in SORTED_VEC_123.iter() {
-
-        let value =  map.get_mut(k);
+        let value = map.get_mut(k);
 
         if let Some(c) = value {
-
             assert_eq!(*c > 0, true);
             *c = 0;
         }
@@ -1678,7 +1609,7 @@ fn tst_update_some_values() {
     let mut v = Vec::new();
 
     map.visit_values(|c| v.push(c.clone()));
-    assert_eq!(v, [0 ; 16]);
+    assert_eq!(v, [0; 16]);
 
     ////////////////////////////////////////////////////
 
@@ -1687,7 +1618,7 @@ fn tst_update_some_values() {
     v.clear();
 
     map.visit_values(|c| v.push(c.clone()));
-    assert_eq!(v, [1 ; 16]);
+    assert_eq!(v, [1; 16]);
 
     ////////////////////////////////////////////////////
 
@@ -1717,10 +1648,8 @@ fn tst_update_some_values() {
     assert_eq!(v, [1, 2, 2, 3, 4, 3, 3, 2, 4, 1, 1, 1, 1, 1, 3, 1]);
 }
 
-
 #[test]
 fn tst_create_with_macro() {
-
     use ternary_tree::tst;
 
     let map = tst!["aba" => "aba", "ab" => "ab", "bc" => "bc", "ac" => "ac",
@@ -1743,18 +1672,74 @@ fn tst_create_with_macro() {
 
     //total size should be around 976 bytes on x64
     assert_eq!(stat.bytes.total >= 488, true);
-    assert_eq!(stat.bytes.total <= 16+20*48, true);
+    assert_eq!(stat.bytes.total <= 16 + 20 * 48, true);
 
     use ternary_tree::DistStat;
 
-    assert_eq!(stat.dist[0], DistStat { matches: 0, sides: 3, depth: 0 });
-    assert_eq!(stat.dist[1], DistStat { matches: 3, sides: 7, depth: 1 });
-    assert_eq!(stat.dist[2], DistStat { matches: 4, sides: 4, depth: 2 });
-    assert_eq!(stat.dist[3], DistStat { matches: 9, sides: 1, depth: 5 });
-    assert_eq!(stat.dist[4], DistStat { matches: 0, sides: 1, depth: 3 });
-    assert_eq!(stat.dist[5], DistStat { matches: 0, sides: 0, depth: 3 });
-    assert_eq!(stat.dist[6], DistStat { matches: 0, sides: 0, depth: 1 });
-    assert_eq!(stat.dist[7], DistStat { matches: 0, sides: 0, depth: 1 });
+    assert_eq!(
+        stat.dist[0],
+        DistStat {
+            matches: 0,
+            sides: 3,
+            depth: 0
+        }
+    );
+    assert_eq!(
+        stat.dist[1],
+        DistStat {
+            matches: 3,
+            sides: 7,
+            depth: 1
+        }
+    );
+    assert_eq!(
+        stat.dist[2],
+        DistStat {
+            matches: 4,
+            sides: 4,
+            depth: 2
+        }
+    );
+    assert_eq!(
+        stat.dist[3],
+        DistStat {
+            matches: 9,
+            sides: 1,
+            depth: 5
+        }
+    );
+    assert_eq!(
+        stat.dist[4],
+        DistStat {
+            matches: 0,
+            sides: 1,
+            depth: 3
+        }
+    );
+    assert_eq!(
+        stat.dist[5],
+        DistStat {
+            matches: 0,
+            sides: 0,
+            depth: 3
+        }
+    );
+    assert_eq!(
+        stat.dist[6],
+        DistStat {
+            matches: 0,
+            sides: 0,
+            depth: 1
+        }
+    );
+    assert_eq!(
+        stat.dist[7],
+        DistStat {
+            matches: 0,
+            sides: 0,
+            depth: 1
+        }
+    );
     assert_eq!(stat.dist.len(), 8);
 
     let mut v = Vec::new();
@@ -1764,10 +1749,8 @@ fn tst_create_with_macro() {
     assert_eq!(v, SORTED_VEC_123);
 }
 
-
 #[test]
 fn tst_pretty_print() {
-
     use ternary_tree::tst;
 
     let map = tst!["ab" => "ab", "aa" => "aa", "ac" => "ac"];


### PR DESCRIPTION
Hello!
I'm new to Rust, so please forgive me if there are some memory-managment issues, or non-idiomatic constructs.
This contribution improves the time complexity guarantees of the data-structure.

Previously, the tree could've been arbitrarily skewed, in the worst case forcing you to perform Omega(|Sigma|*|key|) operations just to locate the key, for example for the set `{a,b,c,..,z,za,zb,...,zz,zza,zzb,...,zzz,...}`. In particular loading the dictionary in lexycographic order would lead to skewed tree. 

This pull requests ensures that each internal node is balanced in the following sense:
```
|left| < 3/4 |self| and |right| < 3/4 |self|
```
where `|T|` denotes number of keys in a tree `T`, which is `|left|+|right|+|middle|+(if value.is_none() {0} else {1})`.
This condition is sufficient to ensure that the access time is `O(|key|+lg |root|)` where `|key|` is number of characters in `key`.
To see this, observe that going left or right decreases the number of keys at least by 25%, and going to middle consumes one character of the key.

In order to maintain the balance, a variant of Scapegoat Tree technique is used: we view the whole ternary tree, as a recursive binary tree of binary trees of binary trees... i.e. we only look at the left&right links, and treat the middle link as attachment point for the next level of this recursive structure. In such binary tree the weight of a node itself (as opposed to: weight of whole subtree) is defined to be the `|middle|+(if value.is_none() {0} else {1})`, and we try to balance these weights according to the same criteria defined earlier, just interpret it as if there was no middle child, and instead include middle subtree's weight in our own.
A single insert or remove operation can be viewed as updating recursively several binary trees, modifying weight of one node by +1 -1 in each. This change can lead to inbalance in one or more of these binary trees. We treat each binary tree separately.
To restore balance in a binary tree we identify the Scapegoat: the unbalanced node closest to the root. We then rebuild the binary subtree rooted at the Scapegoat from scratch: we sort the nodes by in-order traversal, and reconstruct ideally balanced tree from the list of nodes, by choosing the "median" node (the one for which the total weight of nodes before it in the list is at most half the total, and same for the nodes after it) to be the root, and then subdivide the list recursively to build left and right children. This takes `O(|T|)` time where `|T|` is the total weight of this binary subtree, because:
- in order traversal takes time `O(n)` where `n` is the number of nodes, which can not be larger than `O(|T|)` because even though an internal node can have weight 0, it is only permitted (by balancing rule) if it has two children, thus the number of nodes with node zero is bounded by the number of leaves, and each leaf has weight at most 1
- picking the "median" is implemented using binary-search, so takes `O(lg r)` time, where `r` is number of nodes in the list, however, the list is pruned from nodes of weight 0, so can't be longer than its total weight, so the top-most binary search will take `O(lg|T|)`. Because, by construction left and right children will have <50% of the total weight, we can see that on `k`-th level of recursion there will be at most `2^k` binary-searches taking `O(lg|T|-k)` each. Together this sums to `sum_{k=0}^{lg|T|} 2^k(lg|T|-k)` which we can recognize to be the same expression as the cost of the "heappify" construction of a binary heap, which is known to be O(|T|).

This `O(|T|)` cost of rebuild is amortized by the fact that in order for the Scapegoat to become unbalanced, it must have participated in a lot of inserts or remove operations since last rebuild.
In particular, we can associate a potential `P(self)` with node `self`:
``` 
 P(self) = max{4 * max{|left|,|right|} -2 * |self|,0} 
```
Right after rebuild, the `P(self)` must be zero, because `max{|left|,|right|} < |self|/2`.
Each insert or remove can increase or decrese `|left|`, `|right|` and `|self|` just by +-1, and thus increases the potential at most by `O(1)` for the nodes along the update path, and we can afford paying for these potential changes without increasing the overal `O(|key|+lg|T|)` (amortized) cost of the update.
Whenever we need to rebuild, we have `max{|left|,|right|}>=3/4|self|`, and thus `P(self)>=|self|`, so it is sufficient to pay for the rebuild, because the rebuild will "discharge" the Scapegoat's potential bringing it back to 0.

In order to implement above scheme, the `Node<T>` must have a new field `count: usize`, which increases the size of the node from 48 to 56 bytes. That's unfortunate, and I really tried to figure out a scheme similar to AVL, but I see no simple way to use just rotations to restore balance in a weighted tree.

To make up for this cost, I've added a new feature, which is made possible thanks to this new field: `get_nth(n)` which returns n-th key,value pair lexycogaphically.
This means we now have a data structure which can serve not only as key-value map, but also as a indexable sorted array, and in particular: a heap/priority queue.

I've tried to split the changes into self-contained commits:

The first one reformats the code using `cargo fmt` and adds the missing `.gitignore` file.

Then I simplify the `remove_r` logic a bit, although this might be subjective, I know. Unfortunatelly, I had to back off from `remove_leftmost` this idea later, because while it nicely ensures that there are no nodes without value nor middle child, it may severely distrupt the balance when stealling the descendant.

Finally I implement the count, get_nth, and add rebalancing logic.
